### PR TITLE
Correct RetryProcessor

### DIFF
--- a/src/Swarrot/Processor/Retry/RetryProcessor.php
+++ b/src/Swarrot/Processor/Retry/RetryProcessor.php
@@ -33,15 +33,11 @@ class RetryProcessor implements ConfigurableInterface
         } catch (\Exception $e) {
             $properties = $message->getProperties();
 
-            if (!isset($properties['headers'])) {
-                $properties['headers'] = array();
+            $attempts = 0;
+            if (isset($properties['swarrot_retry_attempts'])) {
+                $attempts = $properties['swarrot_retry_attempts'];
             }
-
-            if (!isset($properties['headers']['swarrot_retry_attempts'])) {
-                $properties['headers']['swarrot_retry_attempts'] = 0;
-            }
-
-            $attempts = ++$properties['headers']['swarrot_retry_attempts'];
+            $attempts++;
 
             if ($attempts > $options['retry_attempts']) {
                 if (null !== $this->logger) {
@@ -53,6 +49,12 @@ class RetryProcessor implements ConfigurableInterface
 
                 throw $e;
             }
+
+            // We have to put this key in the "headers" property.
+            if (!isset($properties['headers'])) {
+                $properties['headers'] = array();
+            }
+            $properties['headers']['swarrot_retry_attempts'] = $attempts;
 
             $message = new Message(
                 $message->getBody(),

--- a/src/Swarrot/Processor/Retry/Tests/RetryProcessorTest.php
+++ b/src/Swarrot/Processor/Retry/Tests/RetryProcessorTest.php
@@ -99,7 +99,7 @@ class RetryProcessorTest extends \PHPUnit_Framework_TestCase
         $messagePublisher = $this->prophet->prophesize('Swarrot\Broker\MessagePublisher\MessagePublisherInterface');
         $logger           = $this->prophet->prophesize('Psr\Log\LoggerInterface');
 
-        $message = new Message('body', array('headers' => array('swarrot_retry_attempts' => 1)), 1);
+        $message = new Message('body', array('swarrot_retry_attempts' => 1), 1);
         $options = array(
             'retry_attempts' => 3,
             'retry_key_pattern' => 'key_%attempt%',
@@ -139,7 +139,7 @@ class RetryProcessorTest extends \PHPUnit_Framework_TestCase
         $messagePublisher = $this->prophet->prophesize('Swarrot\Broker\MessagePublisher\MessagePublisherInterface');
         $logger           = $this->prophet->prophesize('Psr\Log\LoggerInterface');
 
-        $message = new Message('body', array('headers' => array('swarrot_retry_attempts' => 3)), 1);
+        $message = new Message('body', array('swarrot_retry_attempts' => 3), 1);
         $options = array(
             'retry_attempts' => 3,
             'retry_key_pattern' => 'key_%attempt%',


### PR DESCRIPTION
@Taluu & @ludofleury
It's a bit more complicated as explained in #16.

In fact when you called the `getHeaders` method on an `\AMQPEnveloppe` it returns both properties and headers at the same level (no key "headers" in this array).
BUT, when you published a message with additional headers, you MUST add it in a "headers" key (otherwise it's dropped by the broker as the additional key is not a valid property).

What do you think of this implementation ?

I think I have to revert commit 87a956ddccda76be904220c5488a64829e5b4bc6 (`getHeaders` => `getProperties`) to be consistent with libraries implementation, are you agree ?
