### PR TITLE
Fixed the branch alias for master

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -43,7 +43,7 @@
     },
     "extra": {
         "branch-alias": {
-            "dev-master": "1.0.x-dev"
+            "dev-master": "1.3.x-dev"
         }
     }
 }


### PR DESCRIPTION
1.2.0 has been released already, so master cannot be a 1.0.x-dev version
