### PR TITLE
[MaxMessagesProcessor] Don't wait new message to shutdown.

### DIFF
--- a/src/Swarrot/Processor/MaxMessages/MaxMessagesProcessor.php
+++ b/src/Swarrot/Processor/MaxMessages/MaxMessagesProcessor.php
@@ -40,7 +40,9 @@ class MaxMessagesProcessor implements ConfigurableInterface
      */
     public function process(Message $message, array $options)
     {
-        if (++$this->messagesProcessed > $options['max_messages']) {
+        $return = $this->processor->process($message, $options);
+
+        if (++$this->messagesProcessed >= $options['max_messages']) {
             if (null !== $this->logger) {
                 $this->logger->info(sprintf(
                     '[MaxMessages] Max messages have been reached (%d)',
@@ -51,7 +53,7 @@ class MaxMessagesProcessor implements ConfigurableInterface
             return false;
         }
 
-        return $this->processor->process($message, $options);
+        return $return;
     }
 
     /**

--- a/tests/Swarrot/Processor/MaxMessages/MaxMessagesProcessorTest.php
+++ b/tests/Swarrot/Processor/MaxMessages/MaxMessagesProcessorTest.php
@@ -62,8 +62,6 @@ class MaxMessagesProcessorTest extends \PHPUnit_Framework_TestCase
 
         // Process
         $this->assertNull($processor->process($message, array('max_messages' => $maxMessages)));
-        // Process
-        $this->assertNull($processor->process($message, array('max_messages' => $maxMessages)));
 
         // Too much messages processed, return false
         $this->assertFalse($processor->process($message, array('max_messages' => $maxMessages)));


### PR DESCRIPTION
When `max_messages` is reached the process is awaiting an other message in order to shutdown.

Here is a simple way to solve this issue but maybe there is a better solution... The process function need to be executed before checking the `max_messages` value.

@odolbeau any idea ?
