### PR TITLE
Correct RetryProcessor

### DIFF
--- a/src/Swarrot/Processor/Retry/RetryProcessor.php
+++ b/src/Swarrot/Processor/Retry/RetryProcessor.php
@@ -49,15 +49,13 @@ class RetryProcessor implements ConfigurableInterface
                 throw $e;
             }
 
-            // We have to put this key in the "headers" property.
-            if (!isset($properties['headers'])) {
-                $properties['headers'] = array();
-            }
-            $properties['headers']['swarrot_retry_attempts'] = $attempts;
-
             $message = new Message(
                 $message->getBody(),
-                $properties
+                array(
+                    'headers' => array(
+                        'swarrot_retry_attempts' => $attempts
+                    )
+                )
             );
 
             $key = str_replace('%attempt%', $attempts, $options['retry_key_pattern']);


### PR DESCRIPTION
@JLepeltier : with the current implementation, the RetryProcessor fail.

It seems that Rabbit doesn't like to receive all the headers from the previous message. :(
