### PR TITLE
Added testing on HHVM and PHP 5.6

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -3,18 +3,15 @@ language: php
 php: [5.4, 5.5, 5.6, hhvm]
 
 matrix:
-    exclude:
-        # Exclude the extra librabbitmq version as HHVM does not use it anyway
-        - { php: hhvm, env: LIBRABBITMQ_VERSION=master }
-
-env:
-  - LIBRABBITMQ_VERSION=master
-  - LIBRABBITMQ_VERSION=v0.5.0
+    include:
+        # Test against librabbitmq cutting-edge
+        - { php: 5.5, env: LIBRABBITMQ_VERSION=master }
 
 services: [rabbitmq]
 
 before_script:
-  - sh -c 'if [ "$TRAVIS_PHP_VERSION" != "hhvm" ]; then ./tests/bin/install_amqp_ext.sh; fi;'
+  - sh -c 'if [ "$LIBRABBITMQ_VERSION" != "" ]; then ./tests/bin/install_librabbitmq.sh; fi;'
+  - sh -c 'if [ "$TRAVIS_PHP_VERSION" != "hhvm" ]; then echo "extension=amqp.so" >> `php --ini | grep "Loaded Configuration" | sed -e "s|.*:\s*||"`; fi;'
   - composer selfupdate
   - composer install --prefer-source
   - sh -c "sudo ./tests/bin/prepare_rabbit.sh"

--- a/tests/bin/install_librabbitmq.sh
+++ b/tests/bin/install_librabbitmq.sh
@@ -8,6 +8,3 @@ cd rabbitmq-c
 git checkout ${LIBRABBITMQ_VERSION}
 git submodule update --init
 autoreconf -i && ./configure && make && sudo make install
-
-echo "# Enabling the AMQP extension"
-echo "extension=amqp.so" >> `php --ini | grep "Loaded Configuration" | sed -e "s|.*:\s*||"`

--- a/tests/bin/prepare_rabbit.sh
+++ b/tests/bin/prepare_rabbit.sh
@@ -1,7 +1,5 @@
 #!/bin/sh
 
-set -e
-
 echo "# Preparing vhost"
 rabbitmqctl delete_vhost swarrot
 rabbitmqctl add_vhost swarrot


### PR DESCRIPTION
This fixes https://github.com/swarrot/swarrot/issues/49

I moved all the installation of the extension to an external file so that excluding it on HHVM can be done a single time instead of doing it for each command.
