### PR TITLE
Switched to the official PHPUnit Prophecy integration

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -16,8 +16,8 @@
         "psr/log": "~1.0"
     },
     "require-dev": {
-        "phpunit/phpunit": "~3.7",
-        "phpspec/prophecy": "~1.1",
+        "phpunit/phpunit": "~4.0",
+        "phpspec/prophecy-phpunit": "~1.0",
         "videlalvaro/php-amqplib": "~2.0"
     },
     "suggest": {

--- a/tests/Swarrot/Broker/MessageProvider/PhpAmqpLibMessageProviderTest.php
+++ b/tests/Swarrot/Broker/MessageProvider/PhpAmqpLibMessageProviderTest.php
@@ -3,29 +3,14 @@
 namespace Swarrot\Broker\MessageProvider;
 
 use PhpAmqpLib\Message\AMQPMessage;
-use Prophecy\Prophet;
+use Prophecy\PhpUnit\ProphecyTestCase;
 use Swarrot\Broker\Message;
 
-class PhpAmqpLibMessageProviderTest extends \PHPUnit_Framework_TestCase
+class PhpAmqpLibMessageProviderTest extends ProphecyTestCase
 {
-    /**
-     * @var Prophet
-     */
-    protected $prophet;
-
-    protected function setUp()
-    {
-        $this->prophet = new Prophet;
-    }
-
-    protected function tearDown()
-    {
-        $this->prophet->checkPredictions();
-    }
-
     public function test_get_with_messages_in_queue_return_message()
     {
-        $channel     = $this->prophet->prophesize('PhpAmqpLib\Channel\AMQPChannel');
+        $channel     = $this->prophesize('PhpAmqpLib\Channel\AMQPChannel');
         $amqpMessage = new AMQPMessage('foobar');
 
         $amqpMessage->delivery_info['delivery_tag'] =  '1';
@@ -40,7 +25,7 @@ class PhpAmqpLibMessageProviderTest extends \PHPUnit_Framework_TestCase
 
     public function test_get_without_messages_in_queue_return_null()
     {
-        $channel = $this->prophet->prophesize('PhpAmqpLib\Channel\AMQPChannel');
+        $channel = $this->prophesize('PhpAmqpLib\Channel\AMQPChannel');
 
         $channel->basic_get('my_queue')->shouldBeCalled()->willReturn(null);
 
@@ -52,7 +37,7 @@ class PhpAmqpLibMessageProviderTest extends \PHPUnit_Framework_TestCase
 
     public function test_ack()
     {
-        $channel = $this->prophet->prophesize('PhpAmqpLib\Channel\AMQPChannel');
+        $channel = $this->prophesize('PhpAmqpLib\Channel\AMQPChannel');
 
         $channel->basic_ack('5')->shouldBeCalled();
 
@@ -63,7 +48,7 @@ class PhpAmqpLibMessageProviderTest extends \PHPUnit_Framework_TestCase
 
     public function test_nack()
     {
-        $channel = $this->prophet->prophesize('PhpAmqpLib\Channel\AMQPChannel');
+        $channel = $this->prophesize('PhpAmqpLib\Channel\AMQPChannel');
 
         $channel->basic_nack('5', false, true)->shouldBeCalled();
 
@@ -74,7 +59,7 @@ class PhpAmqpLibMessageProviderTest extends \PHPUnit_Framework_TestCase
 
     public function test_get_name()
     {
-        $channel = $this->prophet->prophesize('PhpAmqpLib\Channel\AMQPChannel');
+        $channel = $this->prophesize('PhpAmqpLib\Channel\AMQPChannel');
         $provider = new PhpAmqpLibMessageProvider($channel->reveal(), 'foobar');
 
         $this->assertEquals('foobar', $provider->getQueueName());

--- a/tests/Swarrot/Broker/MessagePublisher/PhpAmqpLibMessagePublisherTest.php
+++ b/tests/Swarrot/Broker/MessagePublisher/PhpAmqpLibMessagePublisherTest.php
@@ -2,32 +2,16 @@
 
 namespace Swarrot\Broker\MessagePublisher;
 
-use Prophecy\Prophet;
+use Prophecy\PhpUnit\ProphecyTestCase;
 use Prophecy\Argument;
-
 use PhpAmqpLib\Message\AMQPMessage;
-
-use Swarrot\Broker\MessagePublisher\PhpAmqpLibMessagePublisher;
 use Swarrot\Broker\Message;
 
-class PhpAmqpLibMessagePublisherTest extends \PHPUnit_Framework_TestCase
+class PhpAmqpLibMessagePublisherTest extends ProphecyTestCase
 {
-    /** @var Prophet */
-    protected $prophet;
-
-    public function setUp()
-    {
-        $this->prophet = new Prophet;
-    }
-
-    public function tearDown()
-    {
-        $this->prophet->checkPredictions();
-    }
-
     public function test_publish_with_valid_message()
     {
-        $channel = $this->prophet->prophesize('PhpAmqpLib\Channel\AMQPChannel');
+        $channel = $this->prophesize('PhpAmqpLib\Channel\AMQPChannel');
 
         $channel->basic_publish(
             Argument::that(function(AMQPMessage $message) {

--- a/tests/Swarrot/ConsumerTest.php
+++ b/tests/Swarrot/ConsumerTest.php
@@ -3,32 +3,15 @@
 namespace Swarrot;
 
 use Prophecy\Argument;
-use Swarrot\Broker\MessageProvider\MessageProviderInterface;
-use Swarrot\Processor\ProcessorInterface;
-use Swarrot\Processor\ConfigurableInterface;
-use Swarrot\Processor\InitializableInterface;
-use Swarrot\Processor\TerminableInterface;
-use Swarrot\Processor\SleepyInterface;
+use Prophecy\PhpUnit\ProphecyTestCase;
 use Swarrot\Broker\Message;
 
-class ConsumerTest extends \PHPUnit_Framework_TestCase
+class ConsumerTest extends ProphecyTestCase
 {
-    protected $prophet;
-
-    protected function setUp()
-    {
-        $this->prophet = new \Prophecy\Prophet;
-    }
-
-    protected function tearDown()
-    {
-        $this->prophet->checkPredictions();
-    }
-
     public function test_it_is_initializable()
     {
-        $provider  = $this->prophet->prophesize('Swarrot\Broker\MessageProvider\MessageProviderInterface');
-        $processor = $this->prophet->prophesize('Swarrot\Processor\ProcessorInterface');
+        $provider  = $this->prophesize('Swarrot\Broker\MessageProvider\MessageProviderInterface');
+        $processor = $this->prophesize('Swarrot\Processor\ProcessorInterface');
 
         $consumer = new Consumer($provider->reveal(), $processor->reveal());
         $this->assertInstanceOf('Swarrot\Consumer', $consumer);
@@ -36,8 +19,8 @@ class ConsumerTest extends \PHPUnit_Framework_TestCase
 
     public function test_it_returns_null_if_no_error_occurred()
     {
-        $provider  = $this->prophet->prophesize('Swarrot\Broker\MessageProvider\MessageProviderInterface');
-        $processor = $this->prophet->prophesize('Swarrot\Processor\ProcessorInterface');
+        $provider  = $this->prophesize('Swarrot\Broker\MessageProvider\MessageProviderInterface');
+        $processor = $this->prophesize('Swarrot\Processor\ProcessorInterface');
 
         $message = new Message('body', array(), 1);
 
@@ -53,8 +36,8 @@ class ConsumerTest extends \PHPUnit_Framework_TestCase
 
     public function test_it_call_processor_if_its_configurable()
     {
-        $provider  = $this->prophet->prophesize('Swarrot\Broker\MessageProvider\MessageProviderInterface');
-        $processor = $this->prophet->prophesize('Swarrot\Processor\ConfigurableInterface');
+        $provider  = $this->prophesize('Swarrot\Broker\MessageProvider\MessageProviderInterface');
+        $processor = $this->prophesize('Swarrot\Processor\ConfigurableInterface');
 
         $message = new Message('body', array(), 1);
 
@@ -73,8 +56,8 @@ class ConsumerTest extends \PHPUnit_Framework_TestCase
 
     public function test_it_call_processor_if_its_initializable()
     {
-        $provider  = $this->prophet->prophesize('Swarrot\Broker\MessageProvider\MessageProviderInterface');
-        $processor = $this->prophet->prophesize('Swarrot\Processor\InitializableInterface');
+        $provider  = $this->prophesize('Swarrot\Broker\MessageProvider\MessageProviderInterface');
+        $processor = $this->prophesize('Swarrot\Processor\InitializableInterface');
 
         $message = new Message('body', array(), 1);
 
@@ -91,8 +74,8 @@ class ConsumerTest extends \PHPUnit_Framework_TestCase
 
     public function test_it_call_processor_if_its_terminable()
     {
-        $provider  = $this->prophet->prophesize('Swarrot\Broker\MessageProvider\MessageProviderInterface');
-        $processor = $this->prophet->prophesize('Swarrot\Processor\TerminableInterface');
+        $provider  = $this->prophesize('Swarrot\Broker\MessageProvider\MessageProviderInterface');
+        $processor = $this->prophesize('Swarrot\Processor\TerminableInterface');
 
         $message = new Message('body', array(), 1);
 
@@ -109,8 +92,8 @@ class ConsumerTest extends \PHPUnit_Framework_TestCase
 
     public function test_it_call_processor_if_its_Sleepy()
     {
-        $provider  = $this->prophet->prophesize('Swarrot\Broker\MessageProvider\MessageProviderInterface');
-        $processor = $this->prophet->prophesize('Swarrot\Processor\SleepyInterface');
+        $provider  = $this->prophesize('Swarrot\Broker\MessageProvider\MessageProviderInterface');
+        $processor = $this->prophesize('Swarrot\Processor\SleepyInterface');
 
         $message = new Message('body', array(), 1);
 

--- a/tests/Swarrot/Processor/Ack/AckProcessorTest.php
+++ b/tests/Swarrot/Processor/Ack/AckProcessorTest.php
@@ -3,27 +3,16 @@
 namespace Swarrot\Processor\Ack;
 
 use Prophecy\Argument;
+use Prophecy\PhpUnit\ProphecyTestCase;
 use Swarrot\Broker\Message;
 use Symfony\Component\OptionsResolver\OptionsResolver;
 
-class AckProcessorTest extends \PHPUnit_Framework_TestCase
+class AckProcessorTest extends ProphecyTestCase
 {
-    protected $prophet;
-
-    protected function setUp()
-    {
-        $this->prophet = new \Prophecy\Prophet;
-    }
-
-    protected function tearDown()
-    {
-        $this->prophet->checkPredictions();
-    }
-
     public function test_it_is_initializable_without_a_logger()
     {
-        $processor       = $this->prophet->prophesize('Swarrot\Processor\ProcessorInterface');
-        $messageProvider = $this->prophet->prophesize('Swarrot\Broker\MessageProvider\MessageProviderInterface');
+        $processor       = $this->prophesize('Swarrot\Processor\ProcessorInterface');
+        $messageProvider = $this->prophesize('Swarrot\Broker\MessageProvider\MessageProviderInterface');
 
         $processor = new AckProcessor($processor->reveal(), $messageProvider->reveal());
         $this->assertInstanceOf('Swarrot\Processor\Ack\AckProcessor', $processor);
@@ -31,9 +20,9 @@ class AckProcessorTest extends \PHPUnit_Framework_TestCase
 
     public function test_it_is_initializable_with_a_logger()
     {
-        $processor       = $this->prophet->prophesize('Swarrot\Processor\ProcessorInterface');
-        $messageProvider = $this->prophet->prophesize('Swarrot\Broker\MessageProvider\MessageProviderInterface');
-        $logger          = $this->prophet->prophesize('Psr\Log\LoggerInterface');
+        $processor       = $this->prophesize('Swarrot\Processor\ProcessorInterface');
+        $messageProvider = $this->prophesize('Swarrot\Broker\MessageProvider\MessageProviderInterface');
+        $logger          = $this->prophesize('Psr\Log\LoggerInterface');
 
         $processor = new AckProcessor($processor->reveal(), $messageProvider->reveal(), $logger->reveal());
         $this->assertInstanceOf('Swarrot\Processor\Ack\AckProcessor', $processor);
@@ -41,9 +30,9 @@ class AckProcessorTest extends \PHPUnit_Framework_TestCase
 
     public function test_it_should_ack_when_no_exception_is_thrown()
     {
-        $processor       = $this->prophet->prophesize('Swarrot\Processor\ProcessorInterface');
-        $messageProvider = $this->prophet->prophesize('Swarrot\Broker\MessageProvider\MessageProviderInterface');
-        $logger          = $this->prophet->prophesize('Psr\Log\LoggerInterface');
+        $processor       = $this->prophesize('Swarrot\Processor\ProcessorInterface');
+        $messageProvider = $this->prophesize('Swarrot\Broker\MessageProvider\MessageProviderInterface');
+        $logger          = $this->prophesize('Psr\Log\LoggerInterface');
 
         $message = new Message('body', array(), 1);
 
@@ -56,9 +45,9 @@ class AckProcessorTest extends \PHPUnit_Framework_TestCase
 
     public function test_it_should_nack_when_an_exception_is_thrown()
     {
-        $processor       = $this->prophet->prophesize('Swarrot\Processor\ProcessorInterface');
-        $messageProvider = $this->prophet->prophesize('Swarrot\Broker\MessageProvider\MessageProviderInterface');
-        $logger          = $this->prophet->prophesize('Psr\Log\LoggerInterface');
+        $processor       = $this->prophesize('Swarrot\Processor\ProcessorInterface');
+        $messageProvider = $this->prophesize('Swarrot\Broker\MessageProvider\MessageProviderInterface');
+        $logger          = $this->prophesize('Psr\Log\LoggerInterface');
 
         $message = new Message('body', array(), 1);
 
@@ -73,9 +62,9 @@ class AckProcessorTest extends \PHPUnit_Framework_TestCase
 
     public function test_it_should_nack_and_requeue_when_an_exception_is_thrown_and_conf_updated()
     {
-        $processor       = $this->prophet->prophesize('Swarrot\Processor\ProcessorInterface');
-        $messageProvider = $this->prophet->prophesize('Swarrot\Broker\MessageProvider\MessageProviderInterface');
-        $logger          = $this->prophet->prophesize('Psr\Log\LoggerInterface');
+        $processor       = $this->prophesize('Swarrot\Processor\ProcessorInterface');
+        $messageProvider = $this->prophesize('Swarrot\Broker\MessageProvider\MessageProviderInterface');
+        $logger          = $this->prophesize('Psr\Log\LoggerInterface');
 
         $message = new Message('body', array(), 1);
 
@@ -93,8 +82,8 @@ class AckProcessorTest extends \PHPUnit_Framework_TestCase
 
     public function test_it_should_return_a_valid_array_of_option()
     {
-        $processor       = $this->prophet->prophesize('Swarrot\Processor\ProcessorInterface');
-        $messageProvider = $this->prophet->prophesize('Swarrot\Broker\MessageProvider\MessageProviderInterface');
+        $processor       = $this->prophesize('Swarrot\Processor\ProcessorInterface');
+        $messageProvider = $this->prophesize('Swarrot\Broker\MessageProvider\MessageProviderInterface');
 
         $processor = new AckProcessor($processor->reveal(), $messageProvider->reveal());
 

--- a/tests/Swarrot/Processor/ExceptionCatcher/ExceptionCatcherTest.php
+++ b/tests/Swarrot/Processor/ExceptionCatcher/ExceptionCatcherTest.php
@@ -3,25 +3,14 @@
 namespace Swarrot\Processor\ExceptionCatcher;
 
 use Prophecy\Argument;
+use Prophecy\PhpUnit\ProphecyTestCase;
 use Swarrot\Broker\Message;
 
-class ExceptionCatcherTest extends \PHPUnit_Framework_TestCase
+class ExceptionCatcherTest extends ProphecyTestCase
 {
-    protected $prophet;
-
-    protected function setUp()
-    {
-        $this->prophet = new \Prophecy\Prophet;
-    }
-
-    protected function tearDown()
-    {
-        $this->prophet->checkPredictions();
-    }
-
     public function test_it_is_initializable_without_a_logger()
     {
-        $processor       = $this->prophet->prophesize('Swarrot\Processor\ProcessorInterface');
+        $processor       = $this->prophesize('Swarrot\Processor\ProcessorInterface');
 
         $processor = new ExceptionCatcherProcessor($processor->reveal());
         $this->assertInstanceOf('Swarrot\Processor\ExceptionCatcher\ExceptionCatcherProcessor', $processor);
@@ -29,8 +18,8 @@ class ExceptionCatcherTest extends \PHPUnit_Framework_TestCase
 
     public function test_it_is_initializable_with_a_logger()
     {
-        $processor       = $this->prophet->prophesize('Swarrot\Processor\ProcessorInterface');
-        $logger          = $this->prophet->prophesize('Psr\Log\LoggerInterface');
+        $processor       = $this->prophesize('Swarrot\Processor\ProcessorInterface');
+        $logger          = $this->prophesize('Psr\Log\LoggerInterface');
 
         $processor = new ExceptionCatcherProcessor($processor->reveal(), $logger->reveal());
         $this->assertInstanceOf('Swarrot\Processor\ExceptionCatcher\ExceptionCatcherProcessor', $processor);
@@ -38,8 +27,8 @@ class ExceptionCatcherTest extends \PHPUnit_Framework_TestCase
 
     public function test_it_should_return_void_when_no_exception_is_thrown()
     {
-        $processor       = $this->prophet->prophesize('Swarrot\Processor\ProcessorInterface');
-        $logger          = $this->prophet->prophesize('Psr\Log\LoggerInterface');
+        $processor       = $this->prophesize('Swarrot\Processor\ProcessorInterface');
+        $logger          = $this->prophesize('Psr\Log\LoggerInterface');
 
         $message = new Message('body', array(), 1);
         $processor = new ExceptionCatcherProcessor($processor->reveal(), $logger->reveal());
@@ -48,8 +37,8 @@ class ExceptionCatcherTest extends \PHPUnit_Framework_TestCase
 
     public function test_it_should_throw_an_exception_after_consecutive_failed()
     {
-        $processor       = $this->prophet->prophesize('Swarrot\Processor\ProcessorInterface');
-        $logger          = $this->prophet->prophesize('Psr\Log\LoggerInterface');
+        $processor       = $this->prophesize('Swarrot\Processor\ProcessorInterface');
+        $logger          = $this->prophesize('Psr\Log\LoggerInterface');
 
         $message = new Message('body', array(), 1);
 

--- a/tests/Swarrot/Processor/InstantRetry/InstantRetryProcessorTest.php
+++ b/tests/Swarrot/Processor/InstantRetry/InstantRetryProcessorTest.php
@@ -3,26 +3,15 @@
 namespace spec\Swarrot\Processor\InstantRetry;
 
 use Prophecy\Argument;
+use Prophecy\PhpUnit\ProphecyTestCase;
 use Swarrot\Processor\InstantRetry\InstantRetryProcessor;
 use Swarrot\Broker\Message;
 
-class InstantRetryProcessorTest extends \PHPUnit_Framework_TestCase
+class InstantRetryProcessorTest extends ProphecyTestCase
 {
-    protected $prophet;
-
-    protected function setUp()
-    {
-        $this->prophet = new \Prophecy\Prophet;
-    }
-
-    protected function tearDown()
-    {
-        $this->prophet->checkPredictions();
-    }
-
     public function test_it_is_initializable_without_a_logger()
     {
-        $processor = $this->prophet->prophesize('Swarrot\Processor\ProcessorInterface');
+        $processor = $this->prophesize('Swarrot\Processor\ProcessorInterface');
 
         $processor = new InstantRetryProcessor($processor->reveal());
         $this->assertInstanceOf('Swarrot\Processor\InstantRetry\InstantRetryProcessor', $processor);
@@ -30,8 +19,8 @@ class InstantRetryProcessorTest extends \PHPUnit_Framework_TestCase
 
     public function test_it_is_initializable_with_a_logger()
     {
-        $processor = $this->prophet->prophesize('Swarrot\Processor\ProcessorInterface');
-        $logger    = $this->prophet->prophesize('Psr\Log\LoggerInterface');
+        $processor = $this->prophesize('Swarrot\Processor\ProcessorInterface');
+        $logger    = $this->prophesize('Psr\Log\LoggerInterface');
 
         $processor = new InstantRetryProcessor($processor->reveal(), $logger->reveal());
         $this->assertInstanceOf('Swarrot\Processor\InstantRetry\InstantRetryProcessor', $processor);
@@ -39,8 +28,8 @@ class InstantRetryProcessorTest extends \PHPUnit_Framework_TestCase
 
     public function test_it_should_return_void_when_no_exception_is_thrown()
     {
-        $processor = $this->prophet->prophesize('Swarrot\Processor\ProcessorInterface');
-        $logger    = $this->prophet->prophesize('Psr\Log\LoggerInterface');
+        $processor = $this->prophesize('Swarrot\Processor\ProcessorInterface');
+        $logger    = $this->prophesize('Psr\Log\LoggerInterface');
 
         $message = new Message('body', array(), 1);
 
@@ -56,8 +45,8 @@ class InstantRetryProcessorTest extends \PHPUnit_Framework_TestCase
 
     public function test_it_should_throw_an_exception_after_consecutive_failed()
     {
-        $processor = $this->prophet->prophesize('Swarrot\Processor\ProcessorInterface');
-        $logger    = $this->prophet->prophesize('Psr\Log\LoggerInterface');
+        $processor = $this->prophesize('Swarrot\Processor\ProcessorInterface');
+        $logger    = $this->prophesize('Psr\Log\LoggerInterface');
 
         $message = new Message('body', array(), 1);
 

--- a/tests/Swarrot/Processor/MaxExecutionTime/MaxExecutionTimeProcessorTest.php
+++ b/tests/Swarrot/Processor/MaxExecutionTime/MaxExecutionTimeProcessorTest.php
@@ -3,25 +3,14 @@
 namespace Swarrot\Processor\MaxExecutionTime;
 
 use Prophecy\Argument;
+use Prophecy\PhpUnit\ProphecyTestCase;
 use Swarrot\Broker\Message;
 
-class MaxExecutionTimeProcessorTest extends \PHPUnit_Framework_TestCase
+class MaxExecutionTimeProcessorTest extends ProphecyTestCase
 {
-    protected $prophet;
-
-    protected function setUp()
-    {
-        $this->prophet = new \Prophecy\Prophet;
-    }
-
-    protected function tearDown()
-    {
-        $this->prophet->checkPredictions();
-    }
-
     public function test_it_is_initializable_without_a_logger()
     {
-        $processor = $this->prophet->prophesize('Swarrot\Processor\ProcessorInterface');
+        $processor = $this->prophesize('Swarrot\Processor\ProcessorInterface');
 
         $processor = new MaxExecutionTimeProcessor($processor->reveal());
         $this->assertInstanceOf('Swarrot\Processor\MaxExecutionTime\MaxExecutionTimeProcessor', $processor);
@@ -29,8 +18,8 @@ class MaxExecutionTimeProcessorTest extends \PHPUnit_Framework_TestCase
 
     public function test_it_is_initializable_with_a_logger()
     {
-        $processor = $this->prophet->prophesize('Swarrot\Processor\ProcessorInterface');
-        $logger    = $this->prophet->prophesize('Psr\Log\LoggerInterface');
+        $processor = $this->prophesize('Swarrot\Processor\ProcessorInterface');
+        $logger    = $this->prophesize('Psr\Log\LoggerInterface');
 
         $processor = new MaxExecutionTimeProcessor($processor->reveal(), $logger->reveal());
         $this->assertInstanceOf('Swarrot\Processor\MaxExecutionTime\MaxExecutionTimeProcessor', $processor);
@@ -39,7 +28,7 @@ class MaxExecutionTimeProcessorTest extends \PHPUnit_Framework_TestCase
     public function test_count_default_messages_processed()
     {
         $maxExecutionTime = 1;
-        $processor = $this->prophet->prophesize('Swarrot\Processor\ProcessorInterface');
+        $processor = $this->prophesize('Swarrot\Processor\ProcessorInterface');
         $processor->process(
             Argument::type('Swarrot\Broker\Message'),
             Argument::exact(array(
@@ -47,7 +36,7 @@ class MaxExecutionTimeProcessorTest extends \PHPUnit_Framework_TestCase
             ))
         );
 
-        $logger    = $this->prophet->prophesize('Psr\Log\LoggerInterface');
+        $logger    = $this->prophesize('Psr\Log\LoggerInterface');
         $logger->info(
             Argument::exact(sprintf('[MaxExecutionTime] Max execution time have been reached (%d)', $maxExecutionTime))
         )

--- a/tests/Swarrot/Processor/MaxMessages/MaxMessagesProcessorTest.php
+++ b/tests/Swarrot/Processor/MaxMessages/MaxMessagesProcessorTest.php
@@ -3,25 +3,14 @@
 namespace Swarrot\Processor\MaxMessages;
 
 use Prophecy\Argument;
+use Prophecy\PhpUnit\ProphecyTestCase;
 use Swarrot\Broker\Message;
 
-class MaxMessagesProcessorTest extends \PHPUnit_Framework_TestCase
+class MaxMessagesProcessorTest extends ProphecyTestCase
 {
-    protected $prophet;
-
-    protected function setUp()
-    {
-        $this->prophet = new \Prophecy\Prophet;
-    }
-
-    protected function tearDown()
-    {
-        $this->prophet->checkPredictions();
-    }
-
     public function test_it_is_initializable_without_a_logger()
     {
-        $processor = $this->prophet->prophesize('Swarrot\Processor\ProcessorInterface');
+        $processor = $this->prophesize('Swarrot\Processor\ProcessorInterface');
 
         $processor = new MaxMessagesProcessor($processor->reveal());
         $this->assertInstanceOf('Swarrot\Processor\MaxMessages\MaxMessagesProcessor', $processor);
@@ -29,8 +18,8 @@ class MaxMessagesProcessorTest extends \PHPUnit_Framework_TestCase
 
     public function test_it_is_initializable_with_a_logger()
     {
-        $processor = $this->prophet->prophesize('Swarrot\Processor\ProcessorInterface');
-        $logger    = $this->prophet->prophesize('Psr\Log\LoggerInterface');
+        $processor = $this->prophesize('Swarrot\Processor\ProcessorInterface');
+        $logger    = $this->prophesize('Psr\Log\LoggerInterface');
 
         $processor = new MaxMessagesProcessor($processor->reveal(), $logger->reveal());
         $this->assertInstanceOf('Swarrot\Processor\MaxMessages\MaxMessagesProcessor', $processor);
@@ -39,7 +28,7 @@ class MaxMessagesProcessorTest extends \PHPUnit_Framework_TestCase
     public function test_count_default_messages_processed()
     {
         $maxMessages = 2;
-        $processor = $this->prophet->prophesize('Swarrot\Processor\ProcessorInterface');
+        $processor = $this->prophesize('Swarrot\Processor\ProcessorInterface');
         $processor->process(
             Argument::type('Swarrot\Broker\Message'),
             Argument::exact(array(
@@ -48,7 +37,7 @@ class MaxMessagesProcessorTest extends \PHPUnit_Framework_TestCase
         )
         ->shouldBeCalledTimes(2);
 
-        $logger = $this->prophet->prophesize('Psr\Log\LoggerInterface');
+        $logger = $this->prophesize('Psr\Log\LoggerInterface');
         $logger->info(
             Argument::exact(sprintf('[MaxMessages] Max messages have been reached (%d)', $maxMessages))
         )

--- a/tests/Swarrot/Processor/Retry/RetryProcessorTest.php
+++ b/tests/Swarrot/Processor/Retry/RetryProcessorTest.php
@@ -3,28 +3,16 @@
 namespace Swarrot\Processor\Retry;
 
 use Prophecy\Argument;
+use Prophecy\PhpUnit\ProphecyTestCase;
 use Swarrot\Broker\Message;
 use Symfony\Component\OptionsResolver\OptionsResolver;
-use Swarrot\Broker\MessagePublisher\MessagePublisherInterface;
 
-class RetryProcessorTest extends \PHPUnit_Framework_TestCase
+class RetryProcessorTest extends ProphecyTestCase
 {
-    protected $prophet;
-
-    protected function setUp()
-    {
-        $this->prophet = new \Prophecy\Prophet;
-    }
-
-    protected function tearDown()
-    {
-        $this->prophet->checkPredictions();
-    }
-
     public function test_it_is_initializable_without_a_logger()
     {
-        $processor        = $this->prophet->prophesize('Swarrot\Processor\ProcessorInterface');
-        $messagePublisher = $this->prophet->prophesize('Swarrot\Broker\MessagePublisher\MessagePublisherInterface');
+        $processor        = $this->prophesize('Swarrot\Processor\ProcessorInterface');
+        $messagePublisher = $this->prophesize('Swarrot\Broker\MessagePublisher\MessagePublisherInterface');
 
         $processor = new RetryProcessor($processor->reveal(), $messagePublisher->reveal());
         $this->assertInstanceOf('Swarrot\Processor\Retry\RetryProcessor', $processor);
@@ -32,9 +20,9 @@ class RetryProcessorTest extends \PHPUnit_Framework_TestCase
 
     public function test_it_is_initializable_with_a_logger()
     {
-        $processor        = $this->prophet->prophesize('Swarrot\Processor\ProcessorInterface');
-        $messagePublisher = $this->prophet->prophesize('Swarrot\Broker\MessagePublisher\MessagePublisherInterface');
-        $logger           = $this->prophet->prophesize('Psr\Log\LoggerInterface');
+        $processor        = $this->prophesize('Swarrot\Processor\ProcessorInterface');
+        $messagePublisher = $this->prophesize('Swarrot\Broker\MessagePublisher\MessagePublisherInterface');
+        $logger           = $this->prophesize('Psr\Log\LoggerInterface');
 
         $processor = new RetryProcessor($processor->reveal(), $messagePublisher->reveal(), $logger->reveal());
         $this->assertInstanceOf('Swarrot\Processor\Retry\RetryProcessor', $processor);
@@ -42,9 +30,9 @@ class RetryProcessorTest extends \PHPUnit_Framework_TestCase
 
     public function test_it_should_return_result_when_all_is_right()
     {
-        $processor        = $this->prophet->prophesize('Swarrot\Processor\ProcessorInterface');
-        $messagePublisher = $this->prophet->prophesize('Swarrot\Broker\MessagePublisher\MessagePublisherInterface');
-        $logger           = $this->prophet->prophesize('Psr\Log\LoggerInterface');
+        $processor        = $this->prophesize('Swarrot\Processor\ProcessorInterface');
+        $messagePublisher = $this->prophesize('Swarrot\Broker\MessagePublisher\MessagePublisherInterface');
+        $logger           = $this->prophesize('Psr\Log\LoggerInterface');
 
         $message = new Message('body', array(), 1);
 
@@ -60,9 +48,9 @@ class RetryProcessorTest extends \PHPUnit_Framework_TestCase
 
     public function test_it_should_republished_message_when_an_exception_occurred()
     {
-        $processor        = $this->prophet->prophesize('Swarrot\Processor\ProcessorInterface');
-        $messagePublisher = $this->prophet->prophesize('Swarrot\Broker\MessagePublisher\MessagePublisherInterface');
-        $logger           = $this->prophet->prophesize('Psr\Log\LoggerInterface');
+        $processor        = $this->prophesize('Swarrot\Processor\ProcessorInterface');
+        $messagePublisher = $this->prophesize('Swarrot\Broker\MessagePublisher\MessagePublisherInterface');
+        $logger           = $this->prophesize('Psr\Log\LoggerInterface');
 
         $message = new Message('body', array(), 1);
         $options = array(
@@ -95,9 +83,9 @@ class RetryProcessorTest extends \PHPUnit_Framework_TestCase
 
     public function test_it_should_republished_message_with_incremented_attempts()
     {
-        $processor        = $this->prophet->prophesize('Swarrot\Processor\ProcessorInterface');
-        $messagePublisher = $this->prophet->prophesize('Swarrot\Broker\MessagePublisher\MessagePublisherInterface');
-        $logger           = $this->prophet->prophesize('Psr\Log\LoggerInterface');
+        $processor        = $this->prophesize('Swarrot\Processor\ProcessorInterface');
+        $messagePublisher = $this->prophesize('Swarrot\Broker\MessagePublisher\MessagePublisherInterface');
+        $logger           = $this->prophesize('Psr\Log\LoggerInterface');
 
         $message = new Message('body', array('headers' => array('swarrot_retry_attempts' => 1)), 1);
 
@@ -136,9 +124,9 @@ class RetryProcessorTest extends \PHPUnit_Framework_TestCase
 
     public function test_it_should_throw_exception_if_max_attempts_is_reached()
     {
-        $processor        = $this->prophet->prophesize('Swarrot\Processor\ProcessorInterface');
-        $messagePublisher = $this->prophet->prophesize('Swarrot\Broker\MessagePublisher\MessagePublisherInterface');
-        $logger           = $this->prophet->prophesize('Psr\Log\LoggerInterface');
+        $processor        = $this->prophesize('Swarrot\Processor\ProcessorInterface');
+        $messagePublisher = $this->prophesize('Swarrot\Broker\MessagePublisher\MessagePublisherInterface');
+        $logger           = $this->prophesize('Psr\Log\LoggerInterface');
 
         $message = new Message('body', array('headers' => array('swarrot_retry_attempts' => 3)), 1);
         $options = array(
@@ -169,8 +157,8 @@ class RetryProcessorTest extends \PHPUnit_Framework_TestCase
 
     public function test_it_should_return_a_valid_array_of_option()
     {
-        $processor        = $this->prophet->prophesize('Swarrot\Processor\ProcessorInterface');
-        $messagePublisher = $this->prophet->prophesize('Swarrot\Broker\MessagePublisher\MessagePublisherInterface');
+        $processor        = $this->prophesize('Swarrot\Processor\ProcessorInterface');
+        $messagePublisher = $this->prophesize('Swarrot\Broker\MessagePublisher\MessagePublisherInterface');
 
         $processor = new RetryProcessor($processor->reveal(), $messagePublisher->reveal());
 

--- a/tests/Swarrot/Processor/SignalHandler/SignalHandlerProcessorTest.php
+++ b/tests/Swarrot/Processor/SignalHandler/SignalHandlerProcessorTest.php
@@ -3,25 +3,14 @@
 namespace Swarrot\Processor\SignalHandler;
 
 use Prophecy\Argument;
+use Prophecy\PhpUnit\ProphecyTestCase;
 use Swarrot\Broker\Message;
 
-class SignalHandlerProcessorTest extends \PHPUnit_Framework_TestCase
+class SignalHandlerProcessorTest extends ProphecyTestCase
 {
-    protected $prophet;
-
-    protected function setUp()
-    {
-        $this->prophet = new \Prophecy\Prophet;
-    }
-
-    protected function tearDown()
-    {
-        $this->prophet->checkPredictions();
-    }
-
     public function test_it_is_initializable_without_a_logger()
     {
-        $processor       = $this->prophet->prophesize('Swarrot\Processor\ProcessorInterface');
+        $processor       = $this->prophesize('Swarrot\Processor\ProcessorInterface');
 
         $processor = new SignalHandlerProcessor($processor->reveal());
         $this->assertInstanceOf('Swarrot\Processor\SignalHandler\SignalHandlerProcessor', $processor);
@@ -29,8 +18,8 @@ class SignalHandlerProcessorTest extends \PHPUnit_Framework_TestCase
 
     public function test_it_is_initializable_with_a_logger()
     {
-        $processor       = $this->prophet->prophesize('Swarrot\Processor\ProcessorInterface');
-        $logger          = $this->prophet->prophesize('Psr\Log\LoggerInterface');
+        $processor       = $this->prophesize('Swarrot\Processor\ProcessorInterface');
+        $logger          = $this->prophesize('Psr\Log\LoggerInterface');
 
         $processor = new SignalHandlerProcessor($processor->reveal(), $logger->reveal());
         $this->assertInstanceOf('Swarrot\Processor\SignalHandler\SignalHandlerProcessor', $processor);
@@ -38,8 +27,8 @@ class SignalHandlerProcessorTest extends \PHPUnit_Framework_TestCase
 
     public function test_it_should_return_void_when_no_exception_is_thrown()
     {
-        $processor       = $this->prophet->prophesize('Swarrot\Processor\ProcessorInterface');
-        $logger          = $this->prophet->prophesize('Psr\Log\LoggerInterface');
+        $processor       = $this->prophesize('Swarrot\Processor\ProcessorInterface');
+        $logger          = $this->prophesize('Psr\Log\LoggerInterface');
 
         $message = new Message('body', array(), 1);
         $processor = new SignalHandlerProcessor($processor->reveal(), $logger->reveal());
@@ -48,8 +37,8 @@ class SignalHandlerProcessorTest extends \PHPUnit_Framework_TestCase
 
     public function test_it_should_throw_an_exception_after_consecutive_failed()
     {
-        $processor       = $this->prophet->prophesize('Swarrot\Processor\ProcessorInterface');
-        $logger          = $this->prophet->prophesize('Psr\Log\LoggerInterface');
+        $processor       = $this->prophesize('Swarrot\Processor\ProcessorInterface');
+        $logger          = $this->prophesize('Psr\Log\LoggerInterface');
 
         $message = new Message('body', array(), 1);
 

--- a/tests/Swarrot/Processor/Stack/StackedProcessorTest.php
+++ b/tests/Swarrot/Processor/Stack/StackedProcessorTest.php
@@ -2,33 +2,18 @@
 
 namespace Swarrot\Processor\Stack;
 
-use Swarrot\Processor\InitializableInterface;
-use Swarrot\Processor\TerminableInterface;
-use Swarrot\Processor\ProcessorInterface;
-use Swarrot\Processor\SleepyInterface;
+use Prophecy\PhpUnit\ProphecyTestCase;
 use Swarrot\Broker\Message;
 use Prophecy\Argument;
 
-class StackedProcessorTest extends \PHPUnit_Framework_TestCase
+class StackedProcessorTest extends ProphecyTestCase
 {
-    protected $prophet;
-
-    protected function setUp()
-    {
-        $this->prophet = new \Prophecy\Prophet;
-    }
-
-    protected function tearDown()
-    {
-        $this->prophet->checkPredictions();
-    }
-
     public function test_it_is_initializable()
     {
-        $p1  = $this->prophet->prophesize('Swarrot\Processor\ProcessorInterface');
-        $p2  = $this->prophet->prophesize('Swarrot\Processor\InitializableInterface');
-        $p3  = $this->prophet->prophesize('Swarrot\Processor\TerminableInterface');
-        $p4  = $this->prophet->prophesize('Swarrot\Processor\SleepyInterface');
+        $p1  = $this->prophesize('Swarrot\Processor\ProcessorInterface');
+        $p2  = $this->prophesize('Swarrot\Processor\InitializableInterface');
+        $p3  = $this->prophesize('Swarrot\Processor\TerminableInterface');
+        $p4  = $this->prophesize('Swarrot\Processor\SleepyInterface');
 
         $stackedProcessor = new StackedProcessor(
             $p1->reveal(), array(
@@ -43,10 +28,10 @@ class StackedProcessorTest extends \PHPUnit_Framework_TestCase
 
     public function test_it_is_callable()
     {
-        $p1  = $this->prophet->prophesize('Swarrot\Processor\ProcessorInterface');
-        $p2  = $this->prophet->prophesize('Swarrot\Processor\InitializableInterface');
-        $p3  = $this->prophet->prophesize('Swarrot\Processor\TerminableInterface');
-        $p4  = $this->prophet->prophesize('Swarrot\Processor\SleepyInterface');
+        $p1  = $this->prophesize('Swarrot\Processor\ProcessorInterface');
+        $p2  = $this->prophesize('Swarrot\Processor\InitializableInterface');
+        $p3  = $this->prophesize('Swarrot\Processor\TerminableInterface');
+        $p4  = $this->prophesize('Swarrot\Processor\SleepyInterface');
 
         $p2->initialize(Argument::type('array'))->willReturn(null);
         $p3->terminate(Argument::type('array'))->willReturn(null);
@@ -77,10 +62,10 @@ class StackedProcessorTest extends \PHPUnit_Framework_TestCase
 
     public function test_sleep_return_false_if_at_least_a_processor_return_false()
     {
-        $p1  = $this->prophet->prophesize('Swarrot\Processor\SleepyInterface');
-        $p2  = $this->prophet->prophesize('Swarrot\Processor\SleepyInterface');
-        $p3  = $this->prophet->prophesize('Swarrot\Processor\SleepyInterface');
-        $p4  = $this->prophet->prophesize('Swarrot\Processor\SleepyInterface');
+        $p1  = $this->prophesize('Swarrot\Processor\SleepyInterface');
+        $p2  = $this->prophesize('Swarrot\Processor\SleepyInterface');
+        $p3  = $this->prophesize('Swarrot\Processor\SleepyInterface');
+        $p4  = $this->prophesize('Swarrot\Processor\SleepyInterface');
 
         $p2->sleep(Argument::type('array'))->willReturn(true);
         $p3->sleep(Argument::type('array'))->willReturn(true);


### PR DESCRIPTION
This official integration makes things a bit better than the manual integration you made. If a `shouldBeCalled()` prediction fails, it marks the test as failed rather than errored.

I also updated the PHPUnit constraint to use 4.x rather than the old 3.7
