### PR TITLE
Keep message properties on retry processor

### DIFF
--- a/src/Swarrot/Processor/Doctrine/README.md
+++ b/src/Swarrot/Processor/Doctrine/README.md
@@ -1,6 +1,6 @@
 # ConnectionProcessor
 
-AckProcessor is a [swarrot](https://github.com/swarrot/swarrot) processor.
+ConnectionProcessor is a [swarrot](https://github.com/swarrot/swarrot) processor.
 
 The `doctrine_close_master` option is useful because otherwise once connected
 to the master the connection would never switch back to the slave.
@@ -14,7 +14,7 @@ to the master the connection would never switch back to the slave.
 
 # ObjectManagerProcessor
 
-AckProcessor is a [swarrot](https://github.com/swarrot/swarrot) processor.
+ObjectManagerProcessor is a [swarrot](https://github.com/swarrot/swarrot) processor.
 
 It resets closed object managers after the processor ran, which is required
 after a failed transaction.

--- a/src/Swarrot/Processor/Retry/RetryProcessor.php
+++ b/src/Swarrot/Processor/Retry/RetryProcessor.php
@@ -52,13 +52,13 @@ class RetryProcessor implements ConfigurableInterface
                 throw $e;
             }
 
+            $properties['headers'] = array(
+                'swarrot_retry_attempts' => $attempts
+            );
+
             $message = new Message(
                 $message->getBody(),
-                array(
-                    'headers' => array(
-                        'swarrot_retry_attempts' => $attempts
-                    )
-                )
+                $properties
             );
 
             $key = str_replace('%attempt%', $attempts, $options['retry_key_pattern']);


### PR DESCRIPTION
Actually, with retry processor, only the body of the message is keeped.
When the original message has properties such as "delivery_mode" or "app_id" the copied one loose those properties.

This PR fix that, keep the properties but override the "headers" one.