### PR TITLE
[RPC] Sending a message to a RPC consumer when it shouldn't

### DIFF
--- a/src/Swarrot/Processor/RPC/RpcServerProcessor.php
+++ b/src/Swarrot/Processor/RPC/RpcServerProcessor.php
@@ -41,7 +41,7 @@ class RpcServerProcessor implements ProcessorInterface
 
         $properties = $message->getProperties();
 
-        if (!isset($properties['reply_to'], $properties['correlation_id'])) {
+        if (!isset($properties['reply_to'], $properties['correlation_id']) || empty($properties['reply_to']) || empty($properties['correlation_id'])) {
             return $result;
         }
 

--- a/tests/Swarrot/Processor/RPC/RpcServerProcessorTest.php
+++ b/tests/Swarrot/Processor/RPC/RpcServerProcessorTest.php
@@ -44,12 +44,15 @@ class RpcServerProcessorTest extends ProphecyTestCase
     {
         return [[[]],
                 [['reply_to' => 'foo']],
-                [['correlation_id' => 0]]];
+                [['correlation_id' => 0]],
+                [['reply_to' => '', 'correlation_id' => 0]],
+                [['reply_to' => '', 'correlation_id' => 42]],
+                [['reply_to' => 'foo', 'correlation_id' => 0]]];
     }
 
     public function test_it_should_publish_a_new_message_when_done()
     {
-        $message = new Message('', ['reply_to' => 'foo', 'correlation_id' => 0]);
+        $message = new Message('', ['reply_to' => 'foo', 'correlation_id' => 42]);
 
         $processor = $this->prophesize('Swarrot\\Processor\\ProcessorInterface');
         $processor->process($message, [])->willReturn('bar');


### PR DESCRIPTION
The properties `reply_to` and `correlation_id` are in fact always set, so the processor is always trying to send a new message back to an empty `reply_to` queue with an empty `correlation_id`

I added an empty check, but I'm not sure that `correlation_id` cannot have ld 0` value... or if I should test if it is strictly empty (`''`)