### PR TITLE
Implement the MemoryLimitProcessor

### DIFF
--- a/src/Swarrot/Processor/MemoryLimit/MemoryLimitProcessor.php
+++ b/src/Swarrot/Processor/MemoryLimit/MemoryLimitProcessor.php
@@ -1,0 +1,66 @@
+<?php
+
+namespace Swarrot\Processor\MemoryLimit;
+
+use Psr\Log\LoggerInterface;
+use Swarrot\Broker\Message;
+use Swarrot\Processor\ConfigurableInterface;
+use Swarrot\Processor\ProcessorInterface;
+use Symfony\Component\OptionsResolver\OptionsResolverInterface;
+
+class MemoryLimitProcessor implements ConfigurableInterface
+{
+    /**
+     * @var ProcessorInterface
+     */
+    private $processor;
+
+    /**
+     * @var LoggerInterface
+     */
+    private $logger;
+
+    /**
+     * @param ProcessorInterface $processor Processor
+     * @param LoggerInterface    $logger    Logger
+     */
+    public function __construct(ProcessorInterface $processor, LoggerInterface $logger = null)
+    {
+        $this->processor = $processor;
+        $this->logger    = $logger;
+    }
+    /**
+     * {@inheritDoc}
+     */
+    public function process(Message $message, array $options)
+    {
+        $return = $this->processor->process($message, $options);
+
+        if (null !== $options['memory_limit'] && memory_get_usage() >= $options['memory_limit'] * 1024 * 1024) {
+            $this->logger and $this->logger->info(
+                sprintf('[MemoryLimit] Memory limit has been reached (%d MB)', $options['memory_limit']),
+                [
+                    'swarrot_processor' => 'memory_limit'
+                ]
+            );
+
+            return false;
+        }
+
+        return $return;
+    }
+
+    /**
+     * {@inheritDoc}
+     */
+    public function setDefaultOptions(OptionsResolverInterface $resolver)
+    {
+        $resolver->setDefaults(array(
+            'memory_limit' => null
+        ));
+
+        $resolver->setAllowedTypes(array(
+            'memory_limit' => array('integer', 'null'),
+        ));
+    }
+}

--- a/src/Swarrot/Processor/MemoryLimit/README.md
+++ b/src/Swarrot/Processor/MemoryLimit/README.md
@@ -1,0 +1,12 @@
+# MemoryLimitProcessor
+
+MemoryLimitProcessor is a [swarrot](https://github.com/swarrot/swarrot) processor.
+The goal of this processor is to stop when the memory usages gets over a defined limit, to deal with processors leaking memory during the processing.
+
+## Configuration
+
+|Key             |Default|Description                                |
+|:--------------:|:-----:|-------------------------------------------|
+|memory_limit    |null   |Set the memory limit for the worker (in MB)|
+
+``null`` means unlimited (until you reach the PHP memory limit triggering a fatal error of course)

--- a/tests/Swarrot/Processor/MemoryLimit/MemoryLimitProcessorTest.php
+++ b/tests/Swarrot/Processor/MemoryLimit/MemoryLimitProcessorTest.php
@@ -1,0 +1,50 @@
+<?php
+
+namespace Swarrot\Processor\MemoryLimit;
+
+use Prophecy\Argument;
+use Prophecy\PhpUnit\ProphecyTestCase;
+use Swarrot\Broker\Message;
+
+class MemoryLimitProcessorTest extends ProphecyTestCase
+{
+    public function test_it_is_initializable_without_a_logger()
+    {
+        $processor = $this->prophesize('Swarrot\Processor\ProcessorInterface');
+
+        $processor = new MemoryLimitProcessor($processor->reveal());
+        $this->assertInstanceOf('Swarrot\Processor\MemoryLimit\MemoryLimitProcessor', $processor);
+    }
+
+    public function test_it_is_initializable_with_a_logger()
+    {
+        $processor = $this->prophesize('Swarrot\Processor\ProcessorInterface');
+        $logger    = $this->prophesize('Psr\Log\LoggerInterface');
+
+        $processor = new MemoryLimitProcessor($processor->reveal(), $logger->reveal());
+        $this->assertInstanceOf('Swarrot\Processor\MemoryLimit\MemoryLimitProcessor', $processor);
+    }
+
+    public function test_delegate_processing()
+    {
+        $processor = $this->prophesize('Swarrot\Processor\ProcessorInterface');
+        $processor->process(
+            Argument::type('Swarrot\Broker\Message'),
+            Argument::exact(array(
+                'memory_limit' => null,
+            ))
+        )
+        ->shouldBeCalledTimes(1);
+
+        $logger = $this->prophesize('Psr\Log\LoggerInterface');
+
+        $message = new Message('body', array(), 1);
+        $processor = new MemoryLimitProcessor(
+            $processor->reveal(),
+            $logger->reveal()
+        );
+
+        // Process
+        $this->assertNull($processor->process($message, array('memory_limit' => null)));
+    }
+}


### PR DESCRIPTION
Closes #89

Currently, the default value is to be unlimited, because I don't know what a good generic default could be.

Note that the intended usage is to register it outside the ObjectManagerProcessor (because clearing the entity manager is likely to release memory by deleting references to the entities), or any other processor doing a cleanupof the memory after the processing. The goal is to limit the memory to be leaked after processing (if the processing of a single message reaches the memory limit because of its own needs, there is nothing we can do to intercept it anyway, as we can only hook before or after the logic, not inside it)