### PR TITLE
Add testing against the lowest dependencies on Travis

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -6,6 +6,7 @@ matrix:
     include:
         # Test against librabbitmq cutting-edge
         - { php: 5.5, env: LIBRABBITMQ_VERSION=master }
+        - { php: 5.4, env: COMPOSER_FLAGS='--prefer-lowest --prefer-stable' }
     allow_failures:
         - php: hhvm
 
@@ -15,5 +16,5 @@ before_script:
   - sh -c 'if [ "$LIBRABBITMQ_VERSION" != "" ]; then ./tests/bin/install_librabbitmq.sh; fi;'
   - sh -c 'if [ "$TRAVIS_PHP_VERSION" != "hhvm" ]; then echo "extension=amqp.so" >> `php --ini | grep "Loaded Configuration" | sed -e "s|.*:\s*||"`; fi;'
   - composer selfupdate
-  - composer install --prefer-source
+  - composer update --prefer-source -n $COMPOSER_FLAGS
   - sh -c "sudo ./tests/bin/prepare_rabbit.sh"

--- a/composer.json
+++ b/composer.json
@@ -18,6 +18,7 @@
     "require-dev": {
         "phpunit/phpunit": "~4.0",
         "phpspec/prophecy-phpunit": "~1.0",
+        "phpspec/prophecy": "~1.4",
         "videlalvaro/php-amqplib": "~2.0",
         "doctrine/common": "~2.3",
         "doctrine/dbal": "~2.0"

--- a/composer.json
+++ b/composer.json
@@ -19,13 +19,13 @@
         "phpunit/phpunit": "~4.0",
         "phpspec/prophecy-phpunit": "~1.0",
         "phpspec/prophecy": "~1.4",
-        "videlalvaro/php-amqplib": "~2.0",
+        "videlalvaro/php-amqplib": "~2.1",
         "doctrine/common": "~2.3",
         "doctrine/dbal": "~2.0"
     },
     "suggest": {
         "pecl-amqp": "*",
-        "videlalvaro/php-amqplib": "~2.0",
+        "videlalvaro/php-amqplib": "~2.1",
         "symfony/console": "~2.4"
     },
     "config": {


### PR DESCRIPTION
The goal is to ensure that the lowest bound is set properly, and avoid issues like in https://github.com/swarrot/swarrot/pull/94 breaking the support of older versions