### PR TITLE
Fix compatibility with OptionsResolver <2.6

### DIFF
--- a/src/Swarrot/Processor/Ack/AckProcessor.php
+++ b/src/Swarrot/Processor/Ack/AckProcessor.php
@@ -85,6 +85,13 @@ class AckProcessor implements ConfigurableInterface
             'requeue_on_error' => false
         ));
 
-        $resolver->setAllowedTypes('requeue_on_error', 'bool');
+        if (method_exists($resolver, 'setDefined')) {
+            $resolver->setAllowedTypes('requeue_on_error', 'bool');
+        } else {
+            // BC for OptionsResolver < 2.6
+            $resolver->setAllowedTypes(array(
+                'requeue_on_error' => 'bool',
+            ));
+        }
     }
 }

--- a/src/Swarrot/Processor/MaxExecutionTime/MaxExecutionTimeProcessor.php
+++ b/src/Swarrot/Processor/MaxExecutionTime/MaxExecutionTimeProcessor.php
@@ -47,7 +47,14 @@ class MaxExecutionTimeProcessor implements ConfigurableInterface, InitializableI
             'max_execution_time' => 300
         ));
 
-        $resolver->setAllowedTypes('max_execution_time', 'integer');
+        if (method_exists($resolver, 'setDefined')) {
+            $resolver->setAllowedTypes('max_execution_time', 'int');
+        } else {
+            // BC for OptionsResolver < 2.6
+            $resolver->setAllowedTypes(array(
+                'max_execution_time' => 'int',
+            ));
+        }
     }
 
     /**

--- a/src/Swarrot/Processor/MaxMessages/MaxMessagesProcessor.php
+++ b/src/Swarrot/Processor/MaxMessages/MaxMessagesProcessor.php
@@ -65,6 +65,13 @@ class MaxMessagesProcessor implements ConfigurableInterface
             'max_messages' => 100
         ));
 
-        $resolver->setAllowedTypes('max_messages', 'integer');
+        if (method_exists($resolver, 'setDefined')) {
+            $resolver->setAllowedTypes('max_messages', 'int');
+        } else {
+            // BC for OptionsResolver < 2.6
+            $resolver->setAllowedTypes(array(
+                'max_messages' => 'int',
+            ));
+        }
     }
 }

--- a/src/Swarrot/Processor/Retry/RetryProcessor.php
+++ b/src/Swarrot/Processor/Retry/RetryProcessor.php
@@ -91,8 +91,17 @@ class RetryProcessor implements ConfigurableInterface
             ->setRequired(array(
                 'retry_key_pattern'
             ))
-            ->setAllowedTypes('retry_attempts', 'integer')
-            ->setAllowedTypes('retry_key_pattern', 'string')
         ;
+
+        if (method_exists($resolver, 'setDefined')) {
+            $resolver->setAllowedTypes('retry_attempts', 'int');
+            $resolver->setAllowedTypes('retry_key_pattern', 'string');
+        } else {
+            // BC for OptionsResolver < 2.6
+            $resolver->setAllowedTypes(array(
+                'retry_attempts' => 'int',
+                'retry_key_pattern' => 'string',
+            ));
+        }
     }
 }


### PR DESCRIPTION
https://github.com/swarrot/swarrot/pull/94 broke the compatibility with the 2.3 LTS version by using the API introduced in Symfony 2.6.
This adds support back for 2.3 by detecting whether the new API is available or no (based on the existence of another method of the new API as it is faster and easier than using reflection to detect the number of arguments in the method)