### PR TITLE
Fix the min version for DBAL

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -21,7 +21,7 @@
         "phpspec/prophecy": "~1.4",
         "videlalvaro/php-amqplib": "~2.1",
         "doctrine/common": "~2.3",
-        "doctrine/dbal": "~2.0"
+        "doctrine/dbal": "~2.2"
     },
     "suggest": {
         "pecl-amqp": "*",


### PR DESCRIPTION
Tests are relying on the MasterSlaveConnection added in DBAL 2.2.