### PR TITLE
Add a workaround for the bug in pecl amqp not exposing the delivery mode

### DIFF
--- a/src/Swarrot/Processor/Retry/RetryProcessor.php
+++ b/src/Swarrot/Processor/Retry/RetryProcessor.php
@@ -56,6 +56,11 @@ class RetryProcessor implements ConfigurableInterface
                 'swarrot_retry_attempts' => $attempts,
             );
 
+            // workaround for https://github.com/pdezwart/php-amqp/issues/170. See https://github.com/swarrot/swarrot/issues/103
+            if (isset($properties['delivery_mode']) && 0 === $properties['delivery_mode']) {
+                unset($properties['delivery_mode']);
+            }
+
             $message = new Message(
                 $message->getBody(),
                 $properties


### PR DESCRIPTION
Closes #103 by implementing a workaround until the PECL extension is fixed (if we don't know the original delivery mode, we will just let RabbitMQ use the default one)