### PR TITLE
On retry keep headers except nested arrays

### DIFF
--- a/src/Swarrot/Processor/Retry/RetryProcessor.php
+++ b/src/Swarrot/Processor/Retry/RetryProcessor.php
@@ -52,9 +52,14 @@ class RetryProcessor implements ConfigurableInterface
                 throw $e;
             }
 
-            $properties['headers'] = array(
-                'swarrot_retry_attempts' => $attempts,
-            );
+            // workaround for https://github.com/pdezwart/php-amqp/issues/124
+            if (isset($properties['headers'])) {
+                $properties['headers'] = array_filter($properties['headers'], function($headerValue) {
+                    return ! is_array($headerValue);
+                });
+            }
+            
+            $properties['headers']['swarrot_retry_attempts'] = $attempts;
 
             // workaround for https://github.com/pdezwart/php-amqp/issues/170. See https://github.com/swarrot/swarrot/issues/103
             if (isset($properties['delivery_mode']) && 0 === $properties['delivery_mode']) {


### PR DESCRIPTION
Actually, with retry processor, original message headers are removed to prevent issue described here : https://github.com/pdezwart/php-amqp/issues/124.

This PR allows to keep message headers except nested arrays.