### PR TITLE
Fix publishing headers containing arrays with pecl ext

### DIFF
--- a/src/Swarrot/Broker/MessagePublisher/PeclPackageMessagePublisher.php
+++ b/src/Swarrot/Broker/MessagePublisher/PeclPackageMessagePublisher.php
@@ -55,6 +55,11 @@ class PeclPackageMessagePublisher implements MessagePublisherInterface
             });
         }
         
+        // workaround for https://github.com/pdezwart/php-amqp/issues/170. See https://github.com/swarrot/swarrot/issues/103
+        if (isset($properties['delivery_mode']) && 0 === $properties['delivery_mode']) {
+            unset($properties['delivery_mode']);
+        }
+        
         return $properties;
     }
 

--- a/src/Swarrot/Broker/MessagePublisher/PeclPackageMessagePublisher.php
+++ b/src/Swarrot/Broker/MessagePublisher/PeclPackageMessagePublisher.php
@@ -43,8 +43,19 @@ class PeclPackageMessagePublisher implements MessagePublisherInterface
             $message->getBody(),
             $key,
             $this->flags,
-            $properties
+            $this->sanitizeProperties($properties)
         );
+    }
+    
+    private function sanitizeProperties(array $properties)
+    {
+        if (isset($properties['headers'])) {
+            $properties['headers'] = array_filter($properties['headers'], function($headerValue) {
+                return ! is_array($headerValue);
+            });
+        }
+        
+        return $properties;
     }
 
     /**

--- a/src/Swarrot/Processor/Retry/RetryProcessor.php
+++ b/src/Swarrot/Processor/Retry/RetryProcessor.php
@@ -52,9 +52,10 @@ class RetryProcessor implements ConfigurableInterface
                 throw $e;
             }
 
-            $properties['headers'] = array(
-                'swarrot_retry_attempts' => $attempts,
-            );
+            if (!isset($properties['headers'])) {
+                $properties['headers'] = array();
+            }
+            $properties['headers']['swarrot_retry_attempts'] = $attempts;
 
             // workaround for https://github.com/pdezwart/php-amqp/issues/170. See https://github.com/swarrot/swarrot/issues/103
             if (isset($properties['delivery_mode']) && 0 === $properties['delivery_mode']) {

--- a/src/Swarrot/Processor/Retry/RetryProcessor.php
+++ b/src/Swarrot/Processor/Retry/RetryProcessor.php
@@ -57,11 +57,6 @@ class RetryProcessor implements ConfigurableInterface
             }
             $properties['headers']['swarrot_retry_attempts'] = $attempts;
 
-            // workaround for https://github.com/pdezwart/php-amqp/issues/170. See https://github.com/swarrot/swarrot/issues/103
-            if (isset($properties['delivery_mode']) && 0 === $properties['delivery_mode']) {
-                unset($properties['delivery_mode']);
-            }
-
             $message = new Message(
                 $message->getBody(),
                 $properties

--- a/tests/Swarrot/Broker/MessagePublisher/PeclPackageMessagePublisherTest.php
+++ b/tests/Swarrot/Broker/MessagePublisher/PeclPackageMessagePublisherTest.php
@@ -103,4 +103,26 @@ class PeclPackageMessagePublisherTest extends ProphecyTestCase
 
         $this->assertNull($return);
     }
+
+    public function test_it_should_remove_delivery_mode_property_if_equal_to_zero()
+    {
+        $exchange = $this->prophesize('\AMQPExchange');
+        $exchange
+            ->publish(
+                Argument::exact('body'),
+                Argument::exact(null),
+                Argument::exact(0),
+                Argument::exact([])
+            )
+            ->shouldBeCalledTimes(1)
+        ;
+        $provider = new PeclPackageMessagePublisher($exchange->reveal());
+        $return = $provider->publish(
+            new Message('body', [
+                'delivery_mode' => 0
+            ])
+        );
+    
+        $this->assertNull($return);
+    }
 }

--- a/tests/Swarrot/Broker/MessagePublisher/PeclPackageMessagePublisherTest.php
+++ b/tests/Swarrot/Broker/MessagePublisher/PeclPackageMessagePublisherTest.php
@@ -36,6 +36,38 @@ class PeclPackageMessagePublisherTest extends ProphecyTestCase
 
         $this->assertNull($return);
     }
+    
+    public function test_it_should_remove_nested_arrays_from_headers()
+    {
+        $exchange = $this->prophesize('\AMQPExchange');
+        $exchange
+            ->publish(
+                Argument::exact('body'),
+                Argument::exact(null),
+                Argument::exact(0),
+                Argument::exact([
+                    'headers' => [
+                        'header' => 'value',
+                        'integer' => 42,
+                    ]
+                ])
+            )
+            ->shouldBeCalledTimes(1)
+        ;
+        $provider = new PeclPackageMessagePublisher($exchange->reveal());
+        $return = $provider->publish(
+            new Message('body', [
+                'headers' => [
+                    'header' => 'value',
+                    'integer' => 42,
+                    'array' => ['foo', 'bar'],
+                    'another_array' => ['foo' => ['bar', 'burger']],
+                ]
+            ])
+        );
+        
+        $this->assertNull($return);
+    }
 
     public function test_publish_with_application_headers()
     {
@@ -50,7 +82,6 @@ class PeclPackageMessagePublisherTest extends ProphecyTestCase
                         'another_header' => 'another_value',
                         'string' => 'foobar',
                         'integer' => 42,
-                        'array' => ['foo', 'bar']
                     ]
                 ])
             )


### PR DESCRIPTION
@odolbeau @stof Following discussions on this [pull request](https://github.com/swarrot/swarrot/pull/111), here is a new proposal for a fix. As you were recommending, the correction has been made on pecl implementation of publisher.

I close previous PR.