### PR TITLE
Change log level from warning to error

### DIFF
--- a/src/Swarrot/Processor/Ack/AckProcessor.php
+++ b/src/Swarrot/Processor/Ack/AckProcessor.php
@@ -59,7 +59,7 @@ class AckProcessor implements ConfigurableInterface
             $requeue = isset($options['requeue_on_error']) ? (boolean) $options['requeue_on_error'] : false;
             $this->messageProvider->nack($message, $requeue);
 
-            $this->logger and $this->logger->warning(
+            $this->logger and $this->logger->error(
                 sprintf(
                     '[Ack] An exception occurred. Message #%d have been %s.',
                     $message->getId(),


### PR DESCRIPTION
This is a proposal to change the log level from `warning` to `error` in the `AckProcessor` processor. 

I changed it in order to be more in line with the semantics of the AckProcessor. In my mind, exceptions are errors and should be logged as this. 

Plus, the PSR Log Interface gives us some hint on the right log level we should use: 
- [error level doc](https://github.com/php-fig/log/blob/master/Psr/Log/LoggerInterface.php#L57-L66)
- [warning level doc](https://github.com/php-fig/log/blob/master/Psr/Log/LoggerInterface.php#L68-L79)

