### PR TITLE
Propagating interfaces to decorated processors

### DIFF
--- a/src/Swarrot/Processor/Ack/AckProcessor.php
+++ b/src/Swarrot/Processor/Ack/AckProcessor.php
@@ -4,17 +4,20 @@ namespace Swarrot\Processor\Ack;
 
 use Swarrot\Processor\ProcessorInterface;
 use Swarrot\Processor\ConfigurableInterface;
+use Swarrot\Processor\InitializableInterface;
+use Swarrot\Processor\DecoratorTrait;
+use Swarrot\Processor\SleepyInterface;
+use Swarrot\Processor\TerminableInterface;
 use Swarrot\Broker\MessageProvider\MessageProviderInterface;
 use Swarrot\Broker\Message;
 use Psr\Log\LoggerInterface;
 use Symfony\Component\OptionsResolver\OptionsResolver;
 
-class AckProcessor implements ConfigurableInterface
+class AckProcessor implements ConfigurableInterface, InitializableInterface, SleepyInterface, TerminableInterface
 {
-    /**
-     * @var ProcessorInterface
-     */
-    protected $processor;
+    use DecoratorTrait {
+        DecoratorTrait::setDefaultOptions as traitOptions;
+    }
 
     /**
      * @var MessageProviderInterface
@@ -80,6 +83,8 @@ class AckProcessor implements ConfigurableInterface
      */
     public function setDefaultOptions(OptionsResolver $resolver)
     {
+        $this->traitOptions($resolver);
+
         $resolver->setDefaults(array(
             'requeue_on_error' => false,
         ));

--- a/src/Swarrot/Processor/DecoratorTrait.php
+++ b/src/Swarrot/Processor/DecoratorTrait.php
@@ -1,0 +1,62 @@
+<?php
+namespace Swarrot\Processor;
+
+use Symfony\Component\OptionsResolver\OptionsResolver;
+
+/**
+ * Trait for processors to use if they have a children processor
+ *
+ * This trait is used whenever a processor has a child processor, and thus
+ * must implement all interfaces so that its child's specificities (such as
+ * Configuration, Sleepy, ...) are called.
+ *
+ * @author Baptiste Clavié <clavie.b@gmail.com>
+ */
+trait DecoratorTrait
+{
+    /** @var ProcessorInterface */
+    protected $processor;
+
+    /**
+     * {@inheritdoc}
+     */
+    public function setDefaultOptions(OptionsResolver $resolver)
+    {
+        if ($this->processor instanceof ConfigurableInterface) {
+            $this->processor->setDefaultOptions($resolver);
+        }
+    }
+
+    /**
+     * {@inheritdoc}
+     */
+    public function initialize(array $options)
+    {
+        if ($this->processor instanceof InitializableInterface) {
+            $this->processor->initialize($options);
+        }
+    }
+
+    /**
+     * {@inheritdoc}
+     */
+    public function sleep(array $options)
+    {
+        if ($this->processor instanceof SleepyInterface) {
+            return $this->processor->sleep($options);
+        }
+
+        return true;
+    }
+
+    /**
+     * {@inheritdoc}
+     */
+    public function terminate(array $options)
+    {
+        if ($this->processor instanceof TerminableInterface) {
+            $this->processor->terminate($options);
+        }
+    }
+}
+

--- a/src/Swarrot/Processor/Doctrine/ConnectionProcessor.php
+++ b/src/Swarrot/Processor/Doctrine/ConnectionProcessor.php
@@ -8,18 +8,21 @@ use Doctrine\DBAL\Connections\MasterSlaveConnection;
 use Doctrine\DBAL\DBALException;
 use Swarrot\Broker\Message;
 use Swarrot\Processor\ConfigurableInterface;
+use Swarrot\Processor\InitializableInterface;
 use Swarrot\Processor\ProcessorInterface;
+use Swarrot\Processor\DecoratorTrait;
+use Swarrot\Processor\SleepyInterface;
+use Swarrot\Processor\TerminableInterface;
 use Symfony\Component\OptionsResolver\OptionsResolver;
 
 /**
  * @author Adrien Brault <adrien.brault@gmail.com>
  */
-class ConnectionProcessor implements ConfigurableInterface
+class ConnectionProcessor implements ConfigurableInterface, InitializableInterface, SleepyInterface, TerminableInterface
 {
-    /**
-     * @var ProcessorInterface
-     */
-    private $processor;
+    use DecoratorTrait {
+        DecoratorTrait::setDefaultOptions as traitOptions;
+    }
 
     /**
      * @var Connection[]
@@ -88,6 +91,8 @@ class ConnectionProcessor implements ConfigurableInterface
      */
     public function setDefaultOptions(OptionsResolver $resolver)
     {
+        $this->traitOptions($resolver);
+
         $resolver->setDefaults([
             'doctrine_ping' => true,
             'doctrine_close_master' => true,

--- a/src/Swarrot/Processor/Doctrine/ObjectManagerProcessor.php
+++ b/src/Swarrot/Processor/Doctrine/ObjectManagerProcessor.php
@@ -4,17 +4,18 @@ namespace Swarrot\Processor\Doctrine;
 
 use Doctrine\Common\Persistence\ManagerRegistry;
 use Swarrot\Broker\Message;
+use Swarrot\Processor\InitializableInterface;
 use Swarrot\Processor\ProcessorInterface;
+use Swarrot\Processor\DecoratorTrait;
+use Swarrot\Processor\SleepyInterface;
+use Swarrot\Processor\TerminableInterface;
 
 /**
  * @author Adrien Brault <adrien.brault@gmail.com>
  */
-class ObjectManagerProcessor implements ProcessorInterface
+class ObjectManagerProcessor implements ProcessorInterface, ConfigurableInterface, InitializableInterface, SleepyInterface, TerminableInterface
 {
-    /**
-     * @var ProcessorInterface
-     */
-    private $processor;
+    use DecoratorTrait;
 
     /**
      * @var ManagerRegistry

--- a/src/Swarrot/Processor/ExceptionCatcher/ExceptionCatcherProcessor.php
+++ b/src/Swarrot/Processor/ExceptionCatcher/ExceptionCatcherProcessor.php
@@ -3,15 +3,16 @@
 namespace Swarrot\Processor\ExceptionCatcher;
 
 use Swarrot\Broker\Message;
+use Swarrot\Processor\InitializableInterface;
 use Swarrot\Processor\ProcessorInterface;
+use Swarrot\Processor\DecoratorTrait;
+use Swarrot\Processor\SleepyInterface;
+use Swarrot\Processor\TerminableInterface;
 use Psr\Log\LoggerInterface;
 
-class ExceptionCatcherProcessor implements ProcessorInterface
+class ExceptionCatcherProcessor implements ProcessorInterface, ConfigurableInterface, InitializableInterface, SleepyInterface, TerminableInterface
 {
-    /**
-     * @var ProcessorInterface
-     */
-    protected $processor;
+    use DecoratorTrait;
 
     /**
      * @var LoggerInterface

--- a/src/Swarrot/Processor/Insomniac/InsomniacProcessor.php
+++ b/src/Swarrot/Processor/Insomniac/InsomniacProcessor.php
@@ -3,22 +3,22 @@
 namespace Swarrot\Processor\Insomniac;
 
 use Swarrot\Broker\Message;
+use Swarrot\Processor\InitializableInterface;
 use Swarrot\Processor\ProcessorInterface;
+use Swarrot\Processor\DecoratorTrait;
 use Swarrot\Processor\SleepyInterface;
+use Swarrot\Processor\TerminableInterface;
 use Psr\Log\LoggerInterface;
 
-class InsomniacProcessor implements SleepyInterface
+class InsomniacProcessor implements ProcessorInterface, ConfigurableInterface, InitializableInterface, SleepyInterface, TerminableInterface
 {
-    protected $logger;
+    use DecoratorTrait;
 
-    /**
-     * @var ProcessorInterface
-     */
-    private $decoratedProcessor;
+    protected $logger;
 
     public function __construct(ProcessorInterface $decoratedProcessor, LoggerInterface $logger = null)
     {
-        $this->decoratedProcessor = $decoratedProcessor;
+        $this->processor = $decoratedProcessor;
         $this->logger = $logger;
     }
 
@@ -27,7 +27,7 @@ class InsomniacProcessor implements SleepyInterface
      */
     public function process(Message $message, array $options)
     {
-        return $this->decoratedProcessor->process($message, $options);
+        return $this->processor->process($message, $options);
     }
 
     /**

--- a/src/Swarrot/Processor/InstantRetry/InstantRetryProcessor.php
+++ b/src/Swarrot/Processor/InstantRetry/InstantRetryProcessor.php
@@ -3,17 +3,19 @@
 namespace Swarrot\Processor\InstantRetry;
 
 use Swarrot\Broker\Message;
-use Swarrot\Processor\ConfigurableInterface;
+use Swarrot\Processor\InitializableInterface;
 use Swarrot\Processor\ProcessorInterface;
+use Swarrot\Processor\DecoratorTrait;
+use Swarrot\Processor\SleepyInterface;
+use Swarrot\Processor\TerminableInterface;
 use Psr\Log\LoggerInterface;
 use Symfony\Component\OptionsResolver\OptionsResolver;
 
-class InstantRetryProcessor implements ConfigurableInterface
+class InstantRetryProcessor implements ProcessorInterface, ConfigurableInterface, InitializableInterface, SleepyInterface, TerminableInterface
 {
-    /**
-     * @var ProcessorInterface
-     */
-    protected $processor;
+    use DecoratorTrait {
+        DecoratorTrait::setDefaultOptions as traitOptions;
+    }
 
     /**
      * @var LoggerInterface
@@ -61,6 +63,8 @@ class InstantRetryProcessor implements ConfigurableInterface
      */
     public function setDefaultOptions(OptionsResolver $resolver)
     {
+        $this->traitOptions($resolver);
+
         $resolver->setDefaults(array(
             'instant_retry_delay' => 2000000,
             'instant_retry_attempts' => 3,

--- a/src/Swarrot/Processor/MaxMessages/MaxMessagesProcessor.php
+++ b/src/Swarrot/Processor/MaxMessages/MaxMessagesProcessor.php
@@ -3,17 +3,20 @@
 namespace Swarrot\Processor\MaxMessages;
 
 use Swarrot\Processor\ProcessorInterface;
+use Swarrot\Processor\InitializableInterface;
+use Swarrot\Processor\DecoratorTrait;
+use Swarrot\Processor\SleepyInterface;
+use Swarrot\Processor\TerminableInterface;
 use Swarrot\Processor\ConfigurableInterface;
 use Swarrot\Broker\Message;
 use Psr\Log\LoggerInterface;
 use Symfony\Component\OptionsResolver\OptionsResolver;
 
-class MaxMessagesProcessor implements ConfigurableInterface
+class MaxMessagesProcessor implements ProcessorInterface, ConfigurableInterface, InitializableInterface, SleepyInterface, TerminableInterface
 {
-    /**
-     * @var ProcessorInterface
-     */
-    protected $processor;
+    use DecoratorTrait {
+        DecoratorTrait::setDefaultOptions as decoratorOptions;
+    }
 
     /**
      * @var LoggerInterface
@@ -61,6 +64,8 @@ class MaxMessagesProcessor implements ConfigurableInterface
      */
     public function setDefaultOptions(OptionsResolver $resolver)
     {
+        $this->decoratorOptions($resolver);
+
         $resolver->setDefaults(array(
             'max_messages' => 100,
         ));

--- a/src/Swarrot/Processor/MemoryLimit/MemoryLimitProcessor.php
+++ b/src/Swarrot/Processor/MemoryLimit/MemoryLimitProcessor.php
@@ -4,16 +4,18 @@ namespace Swarrot\Processor\MemoryLimit;
 
 use Psr\Log\LoggerInterface;
 use Swarrot\Broker\Message;
-use Swarrot\Processor\ConfigurableInterface;
+use Swarrot\Processor\InitializableInterface;
+use Swarrot\Processor\DecoratorTrait;
+use Swarrot\Processor\SleepyInterface;
+use Swarrot\Processor\TerminableInterface;
 use Swarrot\Processor\ProcessorInterface;
 use Symfony\Component\OptionsResolver\OptionsResolver;
 
-class MemoryLimitProcessor implements ConfigurableInterface
+class MemoryLimitProcessor implements ProcessorInterface, ConfigurableInterface, InitializableInterface, SleepyInterface, TerminableInterface
 {
-    /**
-     * @var ProcessorInterface
-     */
-    private $processor;
+    use DecoratorTrait {
+        DecoratorTrait::setDefaultOptions as decoratorOptions;
+    }
 
     /**
      * @var LoggerInterface
@@ -55,6 +57,8 @@ class MemoryLimitProcessor implements ConfigurableInterface
      */
     public function setDefaultOptions(OptionsResolver $resolver)
     {
+        $this->decoratorOptions($resolver);
+
         $resolver->setDefaults(array(
             'memory_limit' => null,
         ));

--- a/src/Swarrot/Processor/NewRelic/NewRelicProcessor.php
+++ b/src/Swarrot/Processor/NewRelic/NewRelicProcessor.php
@@ -3,17 +3,19 @@
 namespace Swarrot\Processor\NewRelic;
 
 use Swarrot\Broker\Message;
-use Swarrot\Processor\ConfigurableInterface;
+use Swarrot\Processor\InitializableInterface;
+use Swarrot\Processor\DecoratorTrait;
+use Swarrot\Processor\SleepyInterface;
+use Swarrot\Processor\TerminableInterface;
 use Swarrot\Processor\ProcessorInterface;
 use Symfony\Component\OptionsResolver\Options;
 use Symfony\Component\OptionsResolver\OptionsResolver;
 
-class NewRelicProcessor implements ConfigurableInterface
+class NewRelicProcessor implements ProcessorInterface, ConfigurableInterface, InitializableInterface, SleepyInterface, TerminableInterface
 {
-    /**
-     * @var ProcessorInterface
-     */
-    private $processor;
+    use DecoratorTrait {
+        DecoratorTrait::setDefaultOptions as decoratorOptions;
+    }
 
     /**
      * @var bool
@@ -64,6 +66,8 @@ class NewRelicProcessor implements ConfigurableInterface
      */
     public function setDefaultOptions(OptionsResolver $resolver)
     {
+        $this->decoratorOptions($resolver);
+
         $resolver->setRequired([
             'new_relic_app_name',
         ]);

--- a/src/Swarrot/Processor/RPC/RpcServerProcessor.php
+++ b/src/Swarrot/Processor/RPC/RpcServerProcessor.php
@@ -5,6 +5,10 @@ namespace Swarrot\Processor\RPC;
 use Psr\Log\LoggerInterface;
 use Swarrot\Broker\Message;
 use Swarrot\Broker\MessagePublisher\MessagePublisherInterface;
+use Swarrot\Processor\InitializableInterface;
+use Swarrot\Processor\DecoratorTrait;
+use Swarrot\Processor\SleepyInterface;
+use Swarrot\Processor\TerminableInterface;
 use Swarrot\Processor\ProcessorInterface;
 
 /**
@@ -12,10 +16,9 @@ use Swarrot\Processor\ProcessorInterface;
  *
  * @author Baptiste Clavié <clavie.b@gmail.com>
  */
-class RpcServerProcessor implements ProcessorInterface
+class RpcServerProcessor implements ProcessorInterface, ConfigurableInterface, InitializableInterface, SleepyInterface, TerminableInterface
 {
-    /** @var ProcessorInterface */
-    private $processor;
+    use DecoratorTrait;
 
     /** @var MessagePublisherInterface */
     private $publisher;

--- a/src/Swarrot/Processor/Retry/RetryProcessor.php
+++ b/src/Swarrot/Processor/Retry/RetryProcessor.php
@@ -2,16 +2,22 @@
 
 namespace Swarrot\Processor\Retry;
 
+use Swarrot\Processor\InitializableInterface;
+use Swarrot\Processor\DecoratorTrait;
+use Swarrot\Processor\SleepyInterface;
+use Swarrot\Processor\TerminableInterface;
 use Swarrot\Processor\ProcessorInterface;
-use Swarrot\Processor\ConfigurableInterface;
 use Swarrot\Broker\Message;
 use Psr\Log\LoggerInterface;
 use Symfony\Component\OptionsResolver\OptionsResolver;
 use Swarrot\Broker\MessagePublisher\MessagePublisherInterface;
 
-class RetryProcessor implements ConfigurableInterface
+class RetryProcessor implements ProcessorInterface, ConfigurableInterface, InitializableInterface, SleepyInterface, TerminableInterface
 {
-    protected $processor;
+    use DecoratorTrait {
+        DecoratorTrait::setDefaultOptions as decoratorOptions;
+    }
+
     protected $publisher;
     protected $logger;
 
@@ -85,6 +91,8 @@ class RetryProcessor implements ConfigurableInterface
      */
     public function setDefaultOptions(OptionsResolver $resolver)
     {
+        $this->decoratorOptions($resolver);
+
         $resolver
             ->setDefaults(array(
                 'retry_attempts' => 3,

--- a/src/Swarrot/Processor/SignalHandler/SignalHandlerProcessor.php
+++ b/src/Swarrot/Processor/SignalHandler/SignalHandlerProcessor.php
@@ -3,14 +3,21 @@
 namespace Swarrot\Processor\SignalHandler;
 
 use Swarrot\Broker\Message;
-use Swarrot\Processor\ProcessorInterface;
-use Swarrot\Processor\ConfigurableInterface;
+use Swarrot\Processor\InitializableInterface;
+use Swarrot\Processor\DecoratorTrait;
 use Swarrot\Processor\SleepyInterface;
+use Swarrot\Processor\TerminableInterface;
+use Swarrot\Processor\ProcessorInterface;
 use Psr\Log\LoggerInterface;
 use Symfony\Component\OptionsResolver\OptionsResolver;
 
-class SignalHandlerProcessor implements ConfigurableInterface, SleepyInterface
+class SignalHandlerProcessor implements ProcessorInterface, ConfigurableInterface, InitializableInterface, SleepyInterface, TerminableInterface
 {
+    use DecoratorTrait {
+        DecoratorTrait::setDefaultOptions as decoratorOptions;
+        DecoratorTrait::sleep as decoratorSleep;
+    }
+
     /**
      * @var bool
      */
@@ -52,10 +59,10 @@ class SignalHandlerProcessor implements ConfigurableInterface, SleepyInterface
     public function sleep(array $options)
     {
         if (!extension_loaded('pcntl')) {
-            return true;
+            return $this->decoratorSleep($options);
         }
 
-        return !$this->shouldStop();
+        return !$this->shouldStop() && $this->decoratorSleep($options);
     }
 
     /**

--- a/src/Swarrot/Processor/Stack/StackedProcessor.php
+++ b/src/Swarrot/Processor/Stack/StackedProcessor.php
@@ -39,6 +39,10 @@ class StackedProcessor implements ConfigurableInterface, InitializableInterface,
      */
     public function setDefaultOptions(OptionsResolver $resolver)
     {
+        if ($this->processor instanceof ConfigurableInterface) {
+            $this->processor->setDefaultOptions($resolver);
+        }
+
         foreach ($this->middlewares as $middleware) {
             if ($middleware instanceof ConfigurableInterface) {
                 $middleware->setDefaultOptions($resolver);
@@ -51,6 +55,10 @@ class StackedProcessor implements ConfigurableInterface, InitializableInterface,
      */
     public function initialize(array $options)
     {
+        if ($this->processor instanceof InitializableInterface) {
+            $this->processor->initialize($options);
+        }
+
         foreach ($this->middlewares as $middleware) {
             if ($middleware instanceof InitializableInterface) {
                 $middleware->initialize($options);
@@ -81,6 +89,10 @@ class StackedProcessor implements ConfigurableInterface, InitializableInterface,
      */
     public function terminate(array $options)
     {
+        if ($this->processor instanceof TerminableInterface) {
+            $this->processor->terminate($options);
+        }
+
         foreach ($this->middlewares as $middleware) {
             if ($middleware instanceof TerminableInterface) {
                 $middleware->terminate($options);
@@ -93,6 +105,10 @@ class StackedProcessor implements ConfigurableInterface, InitializableInterface,
      */
     public function sleep(array $options)
     {
+        if (!$this->processor->sleep($options)) {
+            return false;
+        }
+
         foreach ($this->middlewares as $middleware) {
             if ($middleware instanceof SleepyInterface) {
                 if (false === $middleware->sleep($options)) {


### PR DESCRIPTION
On the presented processors in Swarrot, if the decorated processors (design used in almost every processors that are built-in with Swarrot) implements the interfaces that adds things such as options, sleep possibilities, ... etc.

I also added the `ProcessorInterface`, but this is not really in the scope of this PR though (IMO, the interfaces should not extend the `ProcessorInterface`, it does not really make sense). But this is only my opinion though.
