### PR TITLE
Catch PHP7 Throwable

### DIFF
--- a/src/Swarrot/Processor/ExceptionCatcher/ExceptionCatcherProcessor.php
+++ b/src/Swarrot/Processor/ExceptionCatcher/ExceptionCatcherProcessor.php
@@ -31,16 +31,28 @@ class ExceptionCatcherProcessor implements ProcessorInterface
     {
         try {
             return $this->processor->process($message, $options);
+        } catch (\Throwable $e) {
+            $this->handleException($e, $message, $options);
         } catch (\Exception $e) {
-            $this->logger and $this->logger->error(
-                '[ExceptionCatcher] An exception occurred. This exception has been caught.',
-                [
-                    'swarrot_processor' => 'exception',
-                    'exception' => $e,
-                ]
-            );
+            $this->handleException($e, $message, $options);
         }
 
         return;
+    }
+
+    /**
+     * @param Throwable|Exception  $exception
+     * @param Message              $message
+     * @param array                $options
+     */
+    private function handleException($exception, Message $message, array $options)
+    {
+        $this->logger and $this->logger->error(
+            '[ExceptionCatcher] An exception occurred. This exception has been caught.',
+            [
+                'swarrot_processor' => 'exception',
+                'exception' => $exception,
+            ]
+        );
     }
 }

--- a/src/Swarrot/Processor/InstantRetry/InstantRetryProcessor.php
+++ b/src/Swarrot/Processor/InstantRetry/InstantRetryProcessor.php
@@ -36,20 +36,10 @@ class InstantRetryProcessor implements ConfigurableInterface
         while ($retry++ < $options['instant_retry_attempts']) {
             try {
                 return $this->processor->process($message, $options);
+            } catch (\Throwable $e) {
+                $this->handleException($e, $message, $options);
             } catch (\Exception $e) {
-                $this->logger and $this->logger->warning(
-                    sprintf(
-                        '[InstantRetry] An exception occurred. Message #%d will be processed again in %d ms',
-                        $message->getId(),
-                        $options['instant_retry_delay'] / 1000
-                    ),
-                    [
-                        'swarrot_processor' => 'instant_retry',
-                        'exception' => $e,
-                    ]
-                );
-
-                usleep($options['instant_retry_delay']);
+                $this->handleException($e, $message, $options);
             }
         }
 
@@ -65,5 +55,27 @@ class InstantRetryProcessor implements ConfigurableInterface
             'instant_retry_delay' => 2000000,
             'instant_retry_attempts' => 3,
         ));
+    }
+
+    /**
+     * @param \Exception|\Throwable $exception
+     * @param Message               $message
+     * @param array                 $options
+     */
+    private function handleException($exception, Message $message, array $options)
+    {
+        $this->logger and $this->logger->warning(
+            sprintf(
+                '[InstantRetry] An exception occurred. Message #%d will be processed again in %d ms',
+                $message->getId(),
+                $options['instant_retry_delay'] / 1000
+            ),
+            [
+                'swarrot_processor' => 'instant_retry',
+                'exception' => $exception,
+            ]
+        );
+
+        usleep($options['instant_retry_delay']);
     }
 }

--- a/src/Swarrot/Processor/Retry/RetryProcessor.php
+++ b/src/Swarrot/Processor/Retry/RetryProcessor.php
@@ -29,54 +29,10 @@ class RetryProcessor implements ConfigurableInterface
     {
         try {
             return $this->processor->process($message, $options);
+        } catch (\Throwable $e) {
+            $this->handleException($e, $message, $options);
         } catch (\Exception $e) {
-            $properties = $message->getProperties();
-
-            $attempts = 0;
-            if (isset($properties['headers']['swarrot_retry_attempts'])) {
-                $attempts = $properties['headers']['swarrot_retry_attempts'];
-            }
-            ++$attempts;
-
-            if ($attempts > $options['retry_attempts']) {
-                $this->logger and $this->logger->warning(
-                    sprintf(
-                        '[Retry] Stop attempting to process message after %d attempts',
-                        $attempts
-                    ),
-                    [
-                        'swarrot_processor' => 'retry',
-                    ]
-                );
-
-                throw $e;
-            }
-
-            if (!isset($properties['headers'])) {
-                $properties['headers'] = array();
-            }
-            $properties['headers']['swarrot_retry_attempts'] = $attempts;
-
-            $message = new Message(
-                $message->getBody(),
-                $properties
-            );
-
-            $key = str_replace('%attempt%', $attempts, $options['retry_key_pattern']);
-
-            $this->logger and $this->logger->warning(
-                sprintf(
-                    '[Retry] An exception occurred. Republish message for the %d times (key: %s)',
-                    $attempts,
-                    $key
-                ),
-                [
-                    'swarrot_processor' => 'retry',
-                    'exception' => $e,
-                ]
-            );
-
-            $this->publisher->publish($message, $key);
+            $this->handleException($e, $message, $options);
         }
     }
 
@@ -104,5 +60,62 @@ class RetryProcessor implements ConfigurableInterface
                 'retry_key_pattern' => 'string',
             ));
         }
+    }
+
+    /**
+     * @param \Exception|\Throwable $exception
+     * @param Message               $message
+     * @param array                 $options
+     */
+    private function handleException($exception, Message $message, array $options)
+    {
+        $properties = $message->getProperties();
+
+        $attempts = 0;
+        if (isset($properties['headers']['swarrot_retry_attempts'])) {
+            $attempts = $properties['headers']['swarrot_retry_attempts'];
+        }
+        ++$attempts;
+
+        if ($attempts > $options['retry_attempts']) {
+            $this->logger and $this->logger->warning(
+                sprintf(
+                    '[Retry] Stop attempting to process message after %d attempts',
+                    $attempts
+                ),
+                [
+                    'swarrot_processor' => 'retry',
+                ]
+            );
+
+            throw $exception;
+        }
+
+        if (!isset($properties['headers'])) {
+            $properties['headers'] = array();
+        }
+
+        $properties['headers']['swarrot_retry_attempts'] = $attempts;
+
+        $message = new Message(
+            $message->getBody(),
+            $properties
+        );
+
+        $key = str_replace('%attempt%', $attempts, $options['retry_key_pattern']);
+
+        $this->logger and $this->logger->warning(
+            sprintf(
+                '[Retry] An exception occurred. Republish message for the %d times (key: %s)',
+                $attempts,
+                $key
+            ),
+            [
+                'swarrot_processor' => 'retry',
+                'exception' => $exception,
+            ]
+        );
+
+        $this->publisher->publish($message, $key);
     }
 }


### PR DESCRIPTION
Catching Throwable helps to catch a larger range of errors since PHP 7 (and avoid a worker to break while it's running).

Here I duplicated the `catch \Exception` block in order to keep the compatibility with PHP 5.

Note that this logic must be applied in other places:
- AckProcessor
- InstantRetryProcessor
- NewRelicProcessor
- RetryProcessor (need merging #113 first)