### PR TITLE
Fix deprecated warning with OptionsResolver > 2.8

### DIFF
--- a/src/Swarrot/Processor/MemoryLimit/MemoryLimitProcessor.php
+++ b/src/Swarrot/Processor/MemoryLimit/MemoryLimitProcessor.php
@@ -59,8 +59,13 @@ class MemoryLimitProcessor implements ConfigurableInterface
             'memory_limit' => null,
         ));
 
-        $resolver->setAllowedTypes(array(
-            'memory_limit' => array('integer', 'null'),
-        ));
+        if (method_exists($resolver, 'setDefined')) {
+            $resolver->setAllowedTypes('memory_limit', array('integer', 'null'));
+        } else {
+            // BC for OptionsResolver < 2.6
+            $resolver->setAllowedTypes(array(
+                'memory_limit' => array('integer', 'null')
+            ));
+        }
     }
 }


### PR DESCRIPTION
In relation with 6c19f122d4717398f075c7d60d8c5813f8ffccc2
fix the deprecated warning with `setAllowedTypes` for `OptionsResolver` >= 2.8 and fix the error for `OptionsResolver` >= 3.0