### PR TITLE
Log the exception when stopping the retry as well

### DIFF
--- a/src/Swarrot/Processor/Retry/RetryProcessor.php
+++ b/src/Swarrot/Processor/Retry/RetryProcessor.php
@@ -85,6 +85,7 @@ class RetryProcessor implements ConfigurableInterface
                 ),
                 [
                     'swarrot_processor' => 'retry',
+                    'exception' => $exception,
                 ]
             );
 


### PR DESCRIPTION
When retrying, the exception being catched was logged, but not when stopping the retry