### PR TITLE
Allow custom log level by thrown exception

### DIFF
--- a/src/Swarrot/Processor/InstantRetry/InstantRetryProcessor.php
+++ b/src/Swarrot/Processor/InstantRetry/InstantRetryProcessor.php
@@ -2,6 +2,7 @@
 
 namespace Swarrot\Processor\InstantRetry;
 
+use Psr\Log\LogLevel;
 use Swarrot\Broker\Message;
 use Swarrot\Processor\ConfigurableInterface;
 use Swarrot\Processor\ProcessorInterface;
@@ -54,6 +55,7 @@ class InstantRetryProcessor implements ConfigurableInterface
         $resolver->setDefaults(array(
             'instant_retry_delay' => 2000000,
             'instant_retry_attempts' => 3,
+            'instant_retry_log_levels_map' => array(),
         ));
     }
 
@@ -64,18 +66,43 @@ class InstantRetryProcessor implements ConfigurableInterface
      */
     private function handleException($exception, Message $message, array $options)
     {
-        $this->logger and $this->logger->warning(
+        $this->logger and $this->logException(
+            $exception,
             sprintf(
                 '[InstantRetry] An exception occurred. Message #%d will be processed again in %d ms',
                 $message->getId(),
                 $options['instant_retry_delay'] / 1000
             ),
+            $options['instant_retry_log_levels_map']
+        );
+
+        usleep($options['instant_retry_delay']);
+    }
+
+    /**
+     * @param \Exception|\Throwable $exception
+     * @param string                $logMessage
+     * @param array                 $logLevelsMap
+     */
+    private function logException($exception, $logMessage, array $logLevelsMap)
+    {
+        $logLevel = LogLevel::WARNING;
+
+        foreach ($logLevelsMap as $className => $level) {
+            if ($exception instanceof $className) {
+                $logLevel = $level;
+
+                break;
+            }
+        }
+
+        $this->logger->log(
+            $logLevel,
+            $logMessage,
             [
                 'swarrot_processor' => 'instant_retry',
                 'exception' => $exception,
             ]
         );
-
-        usleep($options['instant_retry_delay']);
     }
 }

--- a/src/Swarrot/Processor/InstantRetry/README.md
+++ b/src/Swarrot/Processor/InstantRetry/README.md
@@ -5,7 +5,8 @@ Its goal is to recall the processor when an error occurred.
 
 ## Configuration
 
-|Key                   |Default|Description                                            |
-|:--------------------:|:-----:|-------------------------------------------------------|
-|instant_retry_delay   |2000000|The delay in micro seconds to wait before trying again.|
-|instant_retry_attempts|3      |The number of attempts before raising an exception.    |
+|Key                         |Default|Description                                                   |
+|:--------------------------:|:-----:|--------------------------------------------------------------|
+|instant_retry_delay         |2000000|The delay in micro seconds to wait before trying again.       |
+|instant_retry_attempts      |3      |The number of attempts before raising an exception.           |
+|instant_retry_log_levels_map|[]     |Map of classes to a log level when retry. (Warning by default)|

--- a/src/Swarrot/Processor/Retry/README.md
+++ b/src/Swarrot/Processor/Retry/README.md
@@ -5,10 +5,12 @@ Its goal is to re-published messages in broker when an error occurred.
 
 ## Configuration
 
-|Key              |Default|Description                                                                   |
-|:---------------:|:-----:|------------------------------------------------------------------------------|
-|retry_key_pattern|       |[MANDATORY] The pattern to use to construct routing key (ie: `key_%attempt%`)|
-|retry_attempts   |3      |The number of attempts before raising an exception.                           |
+|Key                      |Default|Description                                                                  |
+|:-----------------------:|:-----:|-----------------------------------------------------------------------------|
+|retry_key_pattern        |       |[MANDATORY] The pattern to use to construct routing key (ie: `key_%attempt%`)|
+|retry_attempts           |3      |The number of attempts before raising an exception.                          |
+|retry_log_levels_map     |[]     |Map of classes to a log level when retry. (Warning by default)               |
+|retry_fail_log_levels_map|[]     |Map of classes to a log level when all retries failed. (Warning by default)  |
 
 ## How it works
 


### PR DESCRIPTION
This is just a POC.

Missing things:
- [x] Update `InstantRetryProcessor`
- [x] Documentation
- [x] Tests

Usage:
Sometimes, you want to retry a message because it's just not yet ready to be processed (for exemple due to an extrenal cause/provider/...), but you don't want to log those retry as warning to not flood your warning logs with those irrelevant logs.

```php
class NotReadyException extends \Exception
{
}
```
```php
$stack = (new \Swarrot\Processor\Stack\Builder())
    ->push(
        'Swarrot\Processor\Retry\RetryProcessor',
        [
            'retry_key_pattern' => 'foo',
            'retry_log_levels_map' => [NotReadyException::class => LogLevel::INFO],
        ]
    )
;
$processor = $stack->resolve(new MyProcessor());
```

Then in the processor:
```php
if (!$object->isReadyToProcess()) {
    throw new NotReadyException('Retry later, the object is not yet ready.');
}
```

What do you think about this?