### PR TITLE
Handle RabbitMQ case when using amqp php extension

### DIFF
--- a/src/Swarrot/Processor/RPC/RpcServerProcessor.php
+++ b/src/Swarrot/Processor/RPC/RpcServerProcessor.php
@@ -6,6 +6,7 @@ use Psr\Log\LoggerInterface;
 use Swarrot\Broker\Message;
 use Swarrot\Broker\MessagePublisher\MessagePublisherInterface;
 use Swarrot\Processor\ProcessorInterface;
+use Symfony\Component\OptionsResolver\OptionsResolver;
 
 /**
  * Act as a RPC server when processing am amqp message.
@@ -35,7 +36,7 @@ class RpcServerProcessor implements ProcessorInterface
     {
         $result = $this->processor->process($message, $options);
 
-        $properties = $message->getProperties();
+        $properties = $this->getProperties($message);
 
         if (!isset($properties['reply_to'], $properties['correlation_id']) || empty($properties['reply_to']) || empty($properties['correlation_id'])) {
             return $result;
@@ -44,8 +45,25 @@ class RpcServerProcessor implements ProcessorInterface
         $this->logger and $this->logger->info(sprintf('sending a new message to the "%s" queue with the id "%s"', $properties['reply_to'], $properties['correlation_id']), ['swarrot_processor' => 'rpc']);
 
         $message = new Message((string) $result, ['correlation_id' => $properties['correlation_id']]);
+
         $this->publisher->publish($message, $properties['reply_to']);
 
         return $result;
+    }
+
+    /**
+     * @param Message $message
+     * @return array
+     */
+    private function getProperties(Message $message)
+    {
+        $properties = $message->getProperties();
+
+        // In AMQP 0.9.1 (RabbitMQ) headers are in a separate key
+        if (isset($properties['headers'])) {
+            $properties = array_merge($properties, $properties['headers']);
+        }
+
+        return $properties;
     }
 }

--- a/tests/Swarrot/Processor/RPC/RpcServerProcessorTest.php
+++ b/tests/Swarrot/Processor/RPC/RpcServerProcessorTest.php
@@ -3,67 +3,96 @@
 namespace Swarrot\Processor\RPC;
 
 use Prophecy\Argument;
+use Prophecy\Prophecy\ObjectProphecy;
+use Psr\Log\LoggerInterface;
 use Swarrot\Broker\Message;
+use Swarrot\Processor\ProcessorInterface;
+use Swarrot\Broker\MessagePublisher\MessagePublisherInterface;
 
 class RpcServerProcessorTest extends \PHPUnit_Framework_TestCase
 {
+    /**
+     * @var ObjectProphecy|ProcessorInterface
+     */
+    private $parentProcessor;
+
+    /**
+     * @var ObjectProphecy|MessagePublisherInterface
+     */
+    private $messagePublisher;
+
+    /**
+     * @var ObjectProphecy|LoggerInterface
+     */
+    private $logger;
+
+    /**
+     * @var RpcServerProcessor
+     */
+    private $processor;
+
+    public function setUp()
+    {
+        $this->parentProcessor = $this->prophesize(ProcessorInterface::class);
+        $this->messagePublisher = $this->prophesize(MessagePublisherInterface::class);
+        $this->logger = $this->prophesize(LoggerInterface::class);
+
+        $this->processor = new RpcServerProcessor(
+            $this->parentProcessor->reveal(),
+            $this->messagePublisher->reveal(),
+            $this->logger->reveal()
+        );
+    }
+
     public function test_it_is_initializable_without_a_logger()
     {
-        $processor        = $this->prophesize('Swarrot\\Processor\\ProcessorInterface');
-        $messagePublisher = $this->prophesize('Swarrot\\Broker\\MessagePublisher\\MessagePublisherInterface');
-
-        $processor = new RpcServerProcessor($processor->reveal(), $messagePublisher->reveal());
+        $processor = new RpcServerProcessor($this->parentProcessor->reveal(), $this->messagePublisher->reveal());
         $this->assertInstanceOf('Swarrot\\Processor\\RPC\\RpcServerProcessor', $processor);
     }
 
     public function test_it_is_initializable_with_a_logger()
     {
-        $processor        = $this->prophesize('Swarrot\\Processor\\ProcessorInterface');
-        $messagePublisher = $this->prophesize('Swarrot\\Broker\\MessagePublisher\\MessagePublisherInterface');
-        $logger           = $this->prophesize('Psr\\Log\\LoggerInterface');
-
-        $processor = new RpcServerProcessor($processor->reveal(), $messagePublisher->reveal(), $logger->reveal());
+        $processor = new RpcServerProcessor(
+            $this->parentProcessor->reveal(),
+            $this->messagePublisher->reveal(),
+            $this->logger->reveal()
+        );
         $this->assertInstanceOf('Swarrot\\Processor\\RPC\\RpcServerProcessor', $processor);
     }
 
     /** @dataProvider noPropertiesProvider */
     public function test_it_should_do_an_early_return_if_no_adequate_properties(array $properties)
     {
-        $processor        = $this->prophesize('Swarrot\\Processor\\ProcessorInterface');
-        $messagePublisher = $this->prophesize('Swarrot\\Broker\\MessagePublisher\\MessagePublisherInterface');
-        $messagePublisher->publish()->shouldNotBeCalled();
-
-        $processor = new RpcServerProcessor($processor->reveal(), $messagePublisher->reveal());
+        $this->messagePublisher->publish()->shouldNotBeCalled();
 
         $message = new Message('', $properties);
-        $this->assertNull($processor->process($message, []));
+        $this->assertNull($this->processor->process($message, []));
     }
 
     public function noPropertiesProvider()
     {
-        return [[[]],
+        return [
+                [[]],
                 [['reply_to' => 'foo']],
                 [['correlation_id' => 0]],
                 [['reply_to' => '', 'correlation_id' => 0]],
                 [['reply_to' => '', 'correlation_id' => 42]],
-                [['reply_to' => 'foo', 'correlation_id' => 0]]];
+                [['reply_to' => 'foo', 'correlation_id' => 0]],
+                [['headers' => ['reply_to' => '', 'correlation_id' => 42]]]
+        ];
     }
 
     public function test_it_should_publish_a_new_message_when_done()
     {
         $message = new Message('', ['reply_to' => 'foo', 'correlation_id' => 42]);
 
-        $processor = $this->prophesize('Swarrot\\Processor\\ProcessorInterface');
-        $processor->process($message, [])->willReturn('bar');
+        $this->parentProcessor->process($message, [])->willReturn('bar');
 
-        $messagePublisher = $this->prophesize('Swarrot\\Broker\\MessagePublisher\\MessagePublisherInterface');
-        $messagePublisher->publish(Argument::that(function ($argument) {
+        $this->messagePublisher->publish(Argument::that(function ($argument) {
             return $argument instanceof Message && 'bar' === $argument->getBody() && array_key_exists('correlation_id', $argument->getProperties());
         }), Argument::is('foo'))->shouldBeCalled();
 
-        $processor = new RpcServerProcessor($processor->reveal(), $messagePublisher->reveal());
-
-        $this->assertSame('bar', $processor->process($message, []));
+        $this->assertSame('bar', $this->processor->process($message, []));
     }
 }
 


### PR DESCRIPTION
With amqp c extension `headers` are in a separate key, so I propose to array_merge it with properties in order to have access to `correlation_id` & `reply_to` keys