### PR TITLE
Use ::class syntax in tests

### DIFF
--- a/tests/Swarrot/Broker/MessageProvider/InteropMessageProviderTest.php
+++ b/tests/Swarrot/Broker/MessageProvider/InteropMessageProviderTest.php
@@ -8,6 +8,7 @@ use Interop\Queue\PsrMessage;
 use Interop\Queue\PsrQueue;
 use Prophecy\Argument;
 use PHPUnit\Framework\TestCase;
+use Swarrot\Broker\Message;
 
 class InteropMessageProviderTest extends TestCase
 {
@@ -87,7 +88,7 @@ class InteropMessageProviderTest extends TestCase
 
         $message = $provider->get();
 
-        $this->assertInstanceOf('Swarrot\Broker\Message', $message);
+        $this->assertInstanceOf(Message::class, $message);
         $this->assertSame('theBody', $message->getBody());
         $this->assertSame([
             'fooHeader' => 'fooHeaderVal',

--- a/tests/Swarrot/Broker/MessageProvider/PeclPackageMessageProviderTest.php
+++ b/tests/Swarrot/Broker/MessageProvider/PeclPackageMessageProviderTest.php
@@ -3,6 +3,7 @@
 namespace Swarrot\Broker\MessageProvider;
 
 use PHPUnit\Framework\TestCase;
+use Swarrot\Broker\Message;
 
 class PeclPackageMessageProviderTest extends TestCase
 {
@@ -18,7 +19,7 @@ class PeclPackageMessageProviderTest extends TestCase
         $provider = new PeclPackageMessageProvider($this->getAMQPQueue('queue_with_messages'));
         $message = $provider->get();
 
-        $this->assertInstanceOf('Swarrot\Broker\Message', $message);
+        $this->assertInstanceOf(Message::class, $message);
     }
 
     public function test_get_without_messages_in_queue_return_null()

--- a/tests/Swarrot/Broker/MessageProvider/PhpAmqpLibMessageProviderTest.php
+++ b/tests/Swarrot/Broker/MessageProvider/PhpAmqpLibMessageProviderTest.php
@@ -5,12 +5,13 @@ namespace Swarrot\Broker\MessageProvider;
 use PhpAmqpLib\Message\AMQPMessage;
 use PHPUnit\Framework\TestCase;
 use Swarrot\Broker\Message;
+use PhpAmqpLib\Channel\AMQPChannel;
 
 class PhpAmqpLibMessageProviderTest extends TestCase
 {
     public function test_get_with_messages_in_queue_return_message()
     {
-        $channel     = $this->prophesize('PhpAmqpLib\Channel\AMQPChannel');
+        $channel     = $this->prophesize(AMQPChannel::class);
         $amqpMessage = new AMQPMessage('foobar');
 
         $amqpMessage->delivery_info['delivery_tag'] =  '1';
@@ -25,7 +26,7 @@ class PhpAmqpLibMessageProviderTest extends TestCase
 
     public function test_get_without_messages_in_queue_return_null()
     {
-        $channel = $this->prophesize('PhpAmqpLib\Channel\AMQPChannel');
+        $channel = $this->prophesize(AMQPChannel::class);
 
         $channel->basic_get('my_queue')->shouldBeCalled()->willReturn(null);
 
@@ -37,7 +38,7 @@ class PhpAmqpLibMessageProviderTest extends TestCase
 
     public function test_ack()
     {
-        $channel = $this->prophesize('PhpAmqpLib\Channel\AMQPChannel');
+        $channel = $this->prophesize(AMQPChannel::class);
 
         $channel->basic_ack('5')->shouldBeCalled();
 
@@ -48,7 +49,7 @@ class PhpAmqpLibMessageProviderTest extends TestCase
 
     public function test_nack()
     {
-        $channel = $this->prophesize('PhpAmqpLib\Channel\AMQPChannel');
+        $channel = $this->prophesize(AMQPChannel::class);
 
         $channel->basic_nack('5', false, true)->shouldBeCalled();
 
@@ -59,7 +60,7 @@ class PhpAmqpLibMessageProviderTest extends TestCase
 
     public function test_get_name()
     {
-        $channel = $this->prophesize('PhpAmqpLib\Channel\AMQPChannel');
+        $channel = $this->prophesize(AMQPChannel::class);
         $provider = new PhpAmqpLibMessageProvider($channel->reveal(), 'foobar');
 
         $this->assertEquals('foobar', $provider->getQueueName());

--- a/tests/Swarrot/Broker/MessagePublisher/InteropMessagePublisherTest.php
+++ b/tests/Swarrot/Broker/MessagePublisher/InteropMessagePublisherTest.php
@@ -4,6 +4,7 @@ namespace Swarrot\Broker\MessagePublisher;
 
 use Interop\Queue\PsrContext;
 use Interop\Queue\PsrMessage;
+use Interop\Queue\PsrProducer;
 use Interop\Queue\PsrTopic;
 use Swarrot\Broker\Message;
 use Prophecy\Argument;
@@ -36,7 +37,7 @@ class InteropMessagePublisherTest extends TestCase
 
         $message = $this->prophesize(PsrMessage::class);
 
-        $producer = $this->prophesize('Interop\Queue\PsrProducer');
+        $producer = $this->prophesize(PsrProducer::class);
         $producer
             ->send(Argument::exact($topic), Argument::exact($message))
             ->shouldBeCalledTimes(1)

--- a/tests/Swarrot/Broker/MessagePublisher/PhpAmqpLibMessagePublisherTest.php
+++ b/tests/Swarrot/Broker/MessagePublisher/PhpAmqpLibMessagePublisherTest.php
@@ -6,12 +6,13 @@ use Prophecy\Argument;
 use PhpAmqpLib\Message\AMQPMessage;
 use PHPUnit\Framework\TestCase;
 use Swarrot\Broker\Message;
+use PhpAmqpLib\Channel\AMQPChannel;
 
 class PhpAmqpLibMessagePublisherTest extends TestCase
 {
     public function test_publish_with_valid_message()
     {
-        $channel = $this->prophesize('PhpAmqpLib\Channel\AMQPChannel');
+        $channel = $this->prophesize(AMQPChannel::class);
 
         $channel->basic_publish(
             Argument::that(function (AMQPMessage $message) {
@@ -34,7 +35,7 @@ class PhpAmqpLibMessagePublisherTest extends TestCase
 
     public function test_publish_with_application_headers()
     {
-        $channel = $this->prophesize('PhpAmqpLib\Channel\AMQPChannel');
+        $channel = $this->prophesize(AMQPChannel::class);
 
         $channel->basic_publish(
             Argument::that(function (AMQPMessage $message) {
@@ -74,10 +75,10 @@ class PhpAmqpLibMessagePublisherTest extends TestCase
 
     public function test_publish_with_publisher_confirms()
     {
-        if (!method_exists('PhpAmqpLib\Channel\AMQPChannel', 'set_nack_handler')) {
+        if (!method_exists(AMQPChannel::class, 'set_nack_handler')) {
             $this->markTestSkipped("The AMQP library version does not support publisher confirms");
         }
-        $channel = $this->prophesize('PhpAmqpLib\Channel\AMQPChannel');
+        $channel = $this->prophesize(AMQPChannel::class);
         $channel->set_nack_handler(
             Argument::type('\Closure')
         )->shouldBeCalledTimes(1);

--- a/tests/Swarrot/ConsumerTest.php
+++ b/tests/Swarrot/ConsumerTest.php
@@ -5,22 +5,29 @@ namespace Swarrot;
 use PHPUnit\Framework\TestCase;
 use Prophecy\Argument;
 use Swarrot\Broker\Message;
+use Swarrot\Broker\MessageProvider\MessageProviderInterface;
+use Swarrot\Processor\InitializableInterface;
+use Swarrot\Processor\ProcessorInterface;
+use Swarrot\Processor\ConfigurableInterface;
+use Swarrot\Processor\SleepyInterface;
+use Swarrot\Processor\TerminableInterface;
+use Symfony\Component\OptionsResolver\OptionsResolver;
 
 class ConsumerTest extends TestCase
 {
     public function test_it_is_initializable()
     {
-        $provider  = $this->prophesize('Swarrot\Broker\MessageProvider\MessageProviderInterface');
-        $processor = $this->prophesize('Swarrot\Processor\ProcessorInterface');
+        $provider  = $this->prophesize(MessageProviderInterface::class);
+        $processor = $this->prophesize(ProcessorInterface::class);
 
         $consumer = new Consumer($provider->reveal(), $processor->reveal());
-        $this->assertInstanceOf('Swarrot\Consumer', $consumer);
+        $this->assertInstanceOf(Consumer::class, $consumer);
     }
 
     public function test_it_returns_null_if_no_error_occurred()
     {
-        $provider  = $this->prophesize('Swarrot\Broker\MessageProvider\MessageProviderInterface');
-        $processor = $this->prophesize('Swarrot\Processor\ProcessorInterface');
+        $provider  = $this->prophesize(MessageProviderInterface::class);
+        $processor = $this->prophesize(ProcessorInterface::class);
 
         $message = new Message('body', array(), 1);
 
@@ -43,15 +50,15 @@ class ConsumerTest extends TestCase
 
     public function test_it_call_processor_if_its_configurable()
     {
-        $provider  = $this->prophesize('Swarrot\Broker\MessageProvider\MessageProviderInterface');
-        $processor = $this->prophesize('Swarrot\Processor\ConfigurableInterface');
+        $provider  = $this->prophesize(MessageProviderInterface::class);
+        $processor = $this->prophesize(ConfigurableInterface::class);
 
         $message = new Message('body', array(), 1);
 
         $provider->get()->willReturn($message);
         $provider->getQueueName()->willReturn('');
         $processor->setDefaultOptions(
-            Argument::type('Symfony\Component\OptionsResolver\OptionsResolver')
+            Argument::type(OptionsResolver::class)
         )->willReturn(null);
         $processor->process(
             $message,
@@ -64,8 +71,8 @@ class ConsumerTest extends TestCase
 
     public function test_it_call_processor_if_its_initializable()
     {
-        $provider  = $this->prophesize('Swarrot\Broker\MessageProvider\MessageProviderInterface');
-        $processor = $this->prophesize('Swarrot\Processor\InitializableInterface');
+        $provider  = $this->prophesize(MessageProviderInterface::class);
+        $processor = $this->prophesize(InitializableInterface::class);
 
         $message = new Message('body', array(), 1);
 
@@ -83,8 +90,8 @@ class ConsumerTest extends TestCase
 
     public function test_it_call_processor_if_its_terminable()
     {
-        $provider  = $this->prophesize('Swarrot\Broker\MessageProvider\MessageProviderInterface');
-        $processor = $this->prophesize('Swarrot\Processor\TerminableInterface');
+        $provider  = $this->prophesize(MessageProviderInterface::class);
+        $processor = $this->prophesize(TerminableInterface::class);
 
         $message = new Message('body', array(), 1);
 
@@ -102,8 +109,8 @@ class ConsumerTest extends TestCase
 
     public function test_it_call_processor_if_its_Sleepy()
     {
-        $provider  = $this->prophesize('Swarrot\Broker\MessageProvider\MessageProviderInterface');
-        $processor = $this->prophesize('Swarrot\Processor\SleepyInterface');
+        $provider  = $this->prophesize(MessageProviderInterface::class);
+        $processor = $this->prophesize(SleepyInterface::class);
 
         $message = new Message('body', array(), 1);
 

--- a/tests/Swarrot/Driver/PrefetchMessageCacheTest.php
+++ b/tests/Swarrot/Driver/PrefetchMessageCacheTest.php
@@ -3,6 +3,7 @@
 namespace Swarrot\Driver;
 
 use PHPUnit\Framework\TestCase;
+use Swarrot\Broker\Message;
 
 /**
  * Class PrefetchMessageCacheTest.
@@ -27,7 +28,7 @@ class PrefetchMessageCacheTest extends TestCase
      */
     public function testInstance()
     {
-        $this->assertInstanceOf('Swarrot\Driver\MessageCacheInterface', $this->driver);
+        $this->assertInstanceOf(MessageCacheInterface::class, $this->driver);
     }
 
     /**
@@ -35,7 +36,7 @@ class PrefetchMessageCacheTest extends TestCase
      */
     public function testPushPop()
     {
-        $message = $this->prophesize('Swarrot\Broker\Message');
+        $message = $this->prophesize(Message::class);
 
         $this->driver->push('foo', $message->reveal());
 
@@ -47,9 +48,9 @@ class PrefetchMessageCacheTest extends TestCase
      */
     public function testMultiplePushPop()
     {
-        $message1 = $this->prophesize('Swarrot\Broker\Message');
-        $message2 = $this->prophesize('Swarrot\Broker\Message');
-        $message3 = $this->prophesize('Swarrot\Broker\Message');
+        $message1 = $this->prophesize(Message::class);
+        $message2 = $this->prophesize(Message::class);
+        $message3 = $this->prophesize(Message::class);
 
         $this->driver->push('foo', $message1->reveal());
         $this->driver->push('foo', $message2->reveal());

--- a/tests/Swarrot/Processor/Ack/AckProcessorTest.php
+++ b/tests/Swarrot/Processor/Ack/AckProcessorTest.php
@@ -6,33 +6,36 @@ use PHPUnit\Framework\TestCase;
 use Prophecy\Argument;
 use Swarrot\Broker\Message;
 use Symfony\Component\OptionsResolver\OptionsResolver;
+use Swarrot\Processor\ProcessorInterface;
+use Swarrot\Broker\MessageProvider\MessageProviderInterface;
+use Psr\Log\LoggerInterface;
 
 class AckProcessorTest extends TestCase
 {
     public function test_it_is_initializable_without_a_logger()
     {
-        $processor       = $this->prophesize('Swarrot\Processor\ProcessorInterface');
-        $messageProvider = $this->prophesize('Swarrot\Broker\MessageProvider\MessageProviderInterface');
+        $processor       = $this->prophesize(ProcessorInterface::class);
+        $messageProvider = $this->prophesize(MessageProviderInterface::class);
 
         $processor = new AckProcessor($processor->reveal(), $messageProvider->reveal());
-        $this->assertInstanceOf('Swarrot\Processor\Ack\AckProcessor', $processor);
+        $this->assertInstanceOf(AckProcessor::class, $processor);
     }
 
     public function test_it_is_initializable_with_a_logger()
     {
-        $processor       = $this->prophesize('Swarrot\Processor\ProcessorInterface');
-        $messageProvider = $this->prophesize('Swarrot\Broker\MessageProvider\MessageProviderInterface');
-        $logger          = $this->prophesize('Psr\Log\LoggerInterface');
+        $processor       = $this->prophesize(ProcessorInterface::class);
+        $messageProvider = $this->prophesize(MessageProviderInterface::class);
+        $logger          = $this->prophesize(LoggerInterface::class);
 
         $processor = new AckProcessor($processor->reveal(), $messageProvider->reveal(), $logger->reveal());
-        $this->assertInstanceOf('Swarrot\Processor\Ack\AckProcessor', $processor);
+        $this->assertInstanceOf(AckProcessor::class, $processor);
     }
 
     public function test_it_should_ack_when_no_exception_is_thrown()
     {
-        $processor       = $this->prophesize('Swarrot\Processor\ProcessorInterface');
-        $messageProvider = $this->prophesize('Swarrot\Broker\MessageProvider\MessageProviderInterface');
-        $logger          = $this->prophesize('Psr\Log\LoggerInterface');
+        $processor       = $this->prophesize(ProcessorInterface::class);
+        $messageProvider = $this->prophesize(MessageProviderInterface::class);
+        $logger          = $this->prophesize(LoggerInterface::class);
 
         $message = new Message('body', array(), 1);
 
@@ -45,9 +48,9 @@ class AckProcessorTest extends TestCase
 
     public function test_it_should_nack_when_an_exception_is_thrown()
     {
-        $processor       = $this->prophesize('Swarrot\Processor\ProcessorInterface');
-        $messageProvider = $this->prophesize('Swarrot\Broker\MessageProvider\MessageProviderInterface');
-        $logger          = $this->prophesize('Psr\Log\LoggerInterface');
+        $processor       = $this->prophesize(ProcessorInterface::class);
+        $messageProvider = $this->prophesize(MessageProviderInterface::class);
+        $logger          = $this->prophesize(LoggerInterface::class);
 
         $message = new Message('body', array(), 1);
 
@@ -62,9 +65,9 @@ class AckProcessorTest extends TestCase
 
     public function test_it_should_nack_and_requeue_when_an_exception_is_thrown_and_conf_updated()
     {
-        $processor       = $this->prophesize('Swarrot\Processor\ProcessorInterface');
-        $messageProvider = $this->prophesize('Swarrot\Broker\MessageProvider\MessageProviderInterface');
-        $logger          = $this->prophesize('Psr\Log\LoggerInterface');
+        $processor       = $this->prophesize(ProcessorInterface::class);
+        $messageProvider = $this->prophesize(MessageProviderInterface::class);
+        $logger          = $this->prophesize(LoggerInterface::class);
 
         $message = new Message('body', array(), 1);
 
@@ -82,8 +85,8 @@ class AckProcessorTest extends TestCase
 
     public function test_it_should_return_a_valid_array_of_option()
     {
-        $processor       = $this->prophesize('Swarrot\Processor\ProcessorInterface');
-        $messageProvider = $this->prophesize('Swarrot\Broker\MessageProvider\MessageProviderInterface');
+        $processor       = $this->prophesize(ProcessorInterface::class);
+        $messageProvider = $this->prophesize(MessageProviderInterface::class);
 
         $processor = new AckProcessor($processor->reveal(), $messageProvider->reveal());
 

--- a/tests/Swarrot/Processor/Doctrine/ObjectManagerProcessorTest.php
+++ b/tests/Swarrot/Processor/Doctrine/ObjectManagerProcessorTest.php
@@ -2,11 +2,13 @@
 
 namespace Swarrot\Processor\Ack;
 
+use Doctrine\Common\Persistence\ManagerRegistry;
 use Doctrine\Common\Persistence\ObjectManager;
 use PHPUnit\Framework\TestCase;
 use Prophecy\Argument;
 use Swarrot\Broker\Message;
 use Swarrot\Processor\Doctrine\ObjectManagerProcessor;
+use Swarrot\Processor\ProcessorInterface;
 
 class ObjectManagerProcessorTest extends TestCase
 {
@@ -15,12 +17,12 @@ class ObjectManagerProcessorTest extends TestCase
         $message = new Message();
         $options = [];
 
-        $innerProcessorProphecy = $this->prophesize('Swarrot\Processor\ProcessorInterface');
+        $innerProcessorProphecy = $this->prophesize(ProcessorInterface::class);
         $innerProcessorProphecy->process($message, $options)->willReturn(true);
 
         $objectManagers = [];
 
-        $objectManagerProphecy = $this->prophesize('Doctrine\Common\Persistence\ObjectManager');
+        $objectManagerProphecy = $this->prophesize(ObjectManager::class);
         $objectManagerProphecy->clear()->shouldBeCalled();
         $objectManagers['default'] = $objectManagerProphecy->reveal();
 
@@ -34,7 +36,7 @@ class ObjectManagerProcessorTest extends TestCase
         $objectManagerProphecy->clear()->shouldNotBeCalled();
         $objectManagers['bar'] = $objectManagerProphecy->reveal();
 
-        $managerRegistryProphecy = $this->prophesize('Doctrine\Common\Persistence\ManagerRegistry');
+        $managerRegistryProphecy = $this->prophesize(ManagerRegistry::class);
         $managerRegistryProphecy->getManagers()->willReturn($objectManagers);
         $managerRegistryProphecy->resetManager('bar')->shouldBeCalled();
 

--- a/tests/Swarrot/Processor/ExceptionCatcher/ExceptionCatcherTest.php
+++ b/tests/Swarrot/Processor/ExceptionCatcher/ExceptionCatcherTest.php
@@ -5,30 +5,32 @@ namespace Swarrot\Processor\ExceptionCatcher;
 use PHPUnit\Framework\TestCase;
 use Prophecy\Argument;
 use Swarrot\Broker\Message;
+use Swarrot\Processor\ProcessorInterface;
+use Psr\Log\LoggerInterface;
 
 class ExceptionCatcherTest extends TestCase
 {
     public function test_it_is_initializable_without_a_logger()
     {
-        $processor       = $this->prophesize('Swarrot\Processor\ProcessorInterface');
+        $processor       = $this->prophesize(ProcessorInterface::class);
 
         $processor = new ExceptionCatcherProcessor($processor->reveal());
-        $this->assertInstanceOf('Swarrot\Processor\ExceptionCatcher\ExceptionCatcherProcessor', $processor);
+        $this->assertInstanceOf(ExceptionCatcherProcessor::class, $processor);
     }
 
     public function test_it_is_initializable_with_a_logger()
     {
-        $processor       = $this->prophesize('Swarrot\Processor\ProcessorInterface');
-        $logger          = $this->prophesize('Psr\Log\LoggerInterface');
+        $processor       = $this->prophesize(ProcessorInterface::class);
+        $logger          = $this->prophesize(LoggerInterface::class);
 
         $processor = new ExceptionCatcherProcessor($processor->reveal(), $logger->reveal());
-        $this->assertInstanceOf('Swarrot\Processor\ExceptionCatcher\ExceptionCatcherProcessor', $processor);
+        $this->assertInstanceOf(ExceptionCatcherProcessor::class, $processor);
     }
 
     public function test_it_should_return_void_when_no_exception_is_thrown()
     {
-        $processor       = $this->prophesize('Swarrot\Processor\ProcessorInterface');
-        $logger          = $this->prophesize('Psr\Log\LoggerInterface');
+        $processor       = $this->prophesize(ProcessorInterface::class);
+        $logger          = $this->prophesize(LoggerInterface::class);
 
         $message = new Message('body', array(), 1);
         $processor = new ExceptionCatcherProcessor($processor->reveal(), $logger->reveal());
@@ -37,8 +39,8 @@ class ExceptionCatcherTest extends TestCase
 
     public function test_it_should_throw_an_exception_after_consecutive_failed()
     {
-        $processor       = $this->prophesize('Swarrot\Processor\ProcessorInterface');
-        $logger          = $this->prophesize('Psr\Log\LoggerInterface');
+        $processor       = $this->prophesize(ProcessorInterface::class);
+        $logger          = $this->prophesize(LoggerInterface::class);
 
         $message = new Message('body', array(), 1);
 

--- a/tests/Swarrot/Processor/Insomniac/InsomniacProcessorTest.php
+++ b/tests/Swarrot/Processor/Insomniac/InsomniacProcessorTest.php
@@ -4,6 +4,7 @@ namespace Swarrot\Processor\Insomniac;
 
 use PHPUnit\Framework\TestCase;
 use Swarrot\Broker\Message;
+use Swarrot\Processor\ProcessorInterface;
 
 class InsomniacProcessorTest extends TestCase
 {
@@ -12,7 +13,7 @@ class InsomniacProcessorTest extends TestCase
         $message = new Message();
         $options = [];
 
-        $decoratedProcessorProphecy = $this->prophesize('Swarrot\Processor\ProcessorInterface');
+        $decoratedProcessorProphecy = $this->prophesize(ProcessorInterface::class);
         $decoratedProcessorProphecy
             ->process($message, $options)
             ->shouldBeCalled()

--- a/tests/Swarrot/Processor/InstantRetry/InstantRetryProcessorTest.php
+++ b/tests/Swarrot/Processor/InstantRetry/InstantRetryProcessorTest.php
@@ -7,30 +7,32 @@ use Prophecy\Argument;
 use Psr\Log\LogLevel;
 use Swarrot\Processor\InstantRetry\InstantRetryProcessor;
 use Swarrot\Broker\Message;
+use Swarrot\Processor\ProcessorInterface;
+use Psr\Log\LoggerInterface;
 
 class InstantRetryProcessorTest extends TestCase
 {
     public function test_it_is_initializable_without_a_logger()
     {
-        $processor = $this->prophesize('Swarrot\Processor\ProcessorInterface');
+        $processor = $this->prophesize(ProcessorInterface::class);
 
         $processor = new InstantRetryProcessor($processor->reveal());
-        $this->assertInstanceOf('Swarrot\Processor\InstantRetry\InstantRetryProcessor', $processor);
+        $this->assertInstanceOf(InstantRetryProcessor::class, $processor);
     }
 
     public function test_it_is_initializable_with_a_logger()
     {
-        $processor = $this->prophesize('Swarrot\Processor\ProcessorInterface');
-        $logger    = $this->prophesize('Psr\Log\LoggerInterface');
+        $processor = $this->prophesize(ProcessorInterface::class);
+        $logger    = $this->prophesize(LoggerInterface::class);
 
         $processor = new InstantRetryProcessor($processor->reveal(), $logger->reveal());
-        $this->assertInstanceOf('Swarrot\Processor\InstantRetry\InstantRetryProcessor', $processor);
+        $this->assertInstanceOf(InstantRetryProcessor::class, $processor);
     }
 
     public function test_it_should_return_void_when_no_exception_is_thrown()
     {
-        $processor = $this->prophesize('Swarrot\Processor\ProcessorInterface');
-        $logger    = $this->prophesize('Psr\Log\LoggerInterface');
+        $processor = $this->prophesize(ProcessorInterface::class);
+        $logger    = $this->prophesize(LoggerInterface::class);
 
         $message = new Message('body', array(), 1);
 
@@ -47,13 +49,13 @@ class InstantRetryProcessorTest extends TestCase
 
     public function test_it_should_throw_an_exception_after_consecutive_failed()
     {
-        $processor = $this->prophesize('Swarrot\Processor\ProcessorInterface');
-        $logger    = $this->prophesize('Psr\Log\LoggerInterface');
+        $processor = $this->prophesize(ProcessorInterface::class);
+        $logger    = $this->prophesize(LoggerInterface::class);
 
         $message = new Message('body', array(), 1);
 
         $processor->process(
-            Argument::type('Swarrot\Broker\Message'),
+            Argument::type(Message::class),
             Argument::exact(array(
                 'instant_retry_attempts' => 3,
                 'instant_retry_delay' => 1000,
@@ -75,14 +77,14 @@ class InstantRetryProcessorTest extends TestCase
 
     public function test_it_should_log_a_warning_by_default_when_an_exception_occurred()
     {
-        $processor        = $this->prophesize('Swarrot\Processor\ProcessorInterface');
-        $logger           = $this->prophesize('Psr\Log\LoggerInterface');
+        $processor        = $this->prophesize(ProcessorInterface::class);
+        $logger           = $this->prophesize(LoggerInterface::class);
         $exception        = new \BadMethodCallException();
 
         $message = new Message('body', array(), 1);
 
         $processor->process(
-            Argument::type('Swarrot\Broker\Message'),
+            Argument::type(Message::class),
             Argument::exact(array(
                 'instant_retry_attempts' => 3,
                 'instant_retry_delay' => 1000,
@@ -116,14 +118,14 @@ class InstantRetryProcessorTest extends TestCase
 
     public function test_it_should_log_a_custom_log_level_when_an_exception_occurred()
     {
-        $processor        = $this->prophesize('Swarrot\Processor\ProcessorInterface');
-        $logger           = $this->prophesize('Psr\Log\LoggerInterface');
+        $processor        = $this->prophesize(ProcessorInterface::class);
+        $logger           = $this->prophesize(LoggerInterface::class);
         $exception        = new \BadMethodCallException();
 
         $message = new Message('body', array(), 1);
 
         $processor->process(
-            Argument::type('Swarrot\Broker\Message'),
+            Argument::type(Message::class),
             Argument::exact(array(
                 'instant_retry_attempts' => 3,
                 'instant_retry_delay' => 1000,
@@ -161,14 +163,14 @@ class InstantRetryProcessorTest extends TestCase
 
     public function test_it_should_log_a_custom_log_level_when_a_child_exception_occurred()
     {
-        $processor        = $this->prophesize('Swarrot\Processor\ProcessorInterface');
-        $logger           = $this->prophesize('Psr\Log\LoggerInterface');
+        $processor        = $this->prophesize(ProcessorInterface::class);
+        $logger           = $this->prophesize(LoggerInterface::class);
         $exception        = new \BadMethodCallException();
 
         $message = new Message('body', array(), 1);
 
         $processor->process(
-            Argument::type('Swarrot\Broker\Message'),
+            Argument::type(Message::class),
             Argument::exact(array(
                 'instant_retry_attempts' => 3,
                 'instant_retry_delay' => 1000,

--- a/tests/Swarrot/Processor/MaxExecutionTime/MaxExecutionTimeProcessorTest.php
+++ b/tests/Swarrot/Processor/MaxExecutionTime/MaxExecutionTimeProcessorTest.php
@@ -5,38 +5,40 @@ namespace Swarrot\Processor\MaxExecutionTime;
 use PHPUnit\Framework\TestCase;
 use Prophecy\Argument;
 use Swarrot\Broker\Message;
+use Swarrot\Processor\ProcessorInterface;
+use Psr\Log\LoggerInterface;
 
 class MaxExecutionTimeProcessorTest extends TestCase
 {
     public function test_it_is_initializable_without_a_logger()
     {
-        $processor = $this->prophesize('Swarrot\Processor\ProcessorInterface');
+        $processor = $this->prophesize(ProcessorInterface::class);
 
         $processor = new MaxExecutionTimeProcessor($processor->reveal());
-        $this->assertInstanceOf('Swarrot\Processor\MaxExecutionTime\MaxExecutionTimeProcessor', $processor);
+        $this->assertInstanceOf(MaxExecutionTimeProcessor::class, $processor);
     }
 
     public function test_it_is_initializable_with_a_logger()
     {
-        $processor = $this->prophesize('Swarrot\Processor\ProcessorInterface');
-        $logger    = $this->prophesize('Psr\Log\LoggerInterface');
+        $processor = $this->prophesize(ProcessorInterface::class);
+        $logger    = $this->prophesize(LoggerInterface::class);
 
         $processor = new MaxExecutionTimeProcessor($processor->reveal(), $logger->reveal());
-        $this->assertInstanceOf('Swarrot\Processor\MaxExecutionTime\MaxExecutionTimeProcessor', $processor);
+        $this->assertInstanceOf(MaxExecutionTimeProcessor::class, $processor);
     }
 
     public function test_count_default_messages_processed()
     {
         $maxExecutionTime = 1;
-        $processor = $this->prophesize('Swarrot\Processor\ProcessorInterface');
+        $processor = $this->prophesize(ProcessorInterface::class);
         $processor->process(
-            Argument::type('Swarrot\Broker\Message'),
+            Argument::type(Message::class),
             Argument::exact(array(
                 'max_execution_time' => $maxExecutionTime,
             ))
         );
 
-        $logger    = $this->prophesize('Psr\Log\LoggerInterface');
+        $logger    = $this->prophesize(LoggerInterface::class);
         $logger->info(
             Argument::exact(sprintf('[MaxExecutionTime] Max execution time have been reached (%d)', $maxExecutionTime)),
             Argument::exact(['swarrot_processor' => 'max_execution_time'])

--- a/tests/Swarrot/Processor/MaxMessages/MaxMessagesProcessorTest.php
+++ b/tests/Swarrot/Processor/MaxMessages/MaxMessagesProcessorTest.php
@@ -5,39 +5,41 @@ namespace Swarrot\Processor\MaxMessages;
 use PHPUnit\Framework\TestCase;
 use Prophecy\Argument;
 use Swarrot\Broker\Message;
+use Psr\Log\LoggerInterface;
+use Swarrot\Processor\ProcessorInterface;
 
 class MaxMessagesProcessorTest extends TestCase
 {
     public function test_it_is_initializable_without_a_logger()
     {
-        $processor = $this->prophesize('Swarrot\Processor\ProcessorInterface');
+        $processor = $this->prophesize(ProcessorInterface::class);
 
         $processor = new MaxMessagesProcessor($processor->reveal());
-        $this->assertInstanceOf('Swarrot\Processor\MaxMessages\MaxMessagesProcessor', $processor);
+        $this->assertInstanceOf(MaxMessagesProcessor::class, $processor);
     }
 
     public function test_it_is_initializable_with_a_logger()
     {
-        $processor = $this->prophesize('Swarrot\Processor\ProcessorInterface');
-        $logger    = $this->prophesize('Psr\Log\LoggerInterface');
+        $processor = $this->prophesize(ProcessorInterface::class);
+        $logger    = $this->prophesize(LoggerInterface::class);
 
         $processor = new MaxMessagesProcessor($processor->reveal(), $logger->reveal());
-        $this->assertInstanceOf('Swarrot\Processor\MaxMessages\MaxMessagesProcessor', $processor);
+        $this->assertInstanceOf(MaxMessagesProcessor::class, $processor);
     }
 
     public function test_count_default_messages_processed()
     {
         $maxMessages = 2;
-        $processor = $this->prophesize('Swarrot\Processor\ProcessorInterface');
+        $processor = $this->prophesize(ProcessorInterface::class);
         $processor->process(
-            Argument::type('Swarrot\Broker\Message'),
+            Argument::type(Message::class),
             Argument::exact(array(
                 'max_messages' => $maxMessages,
             ))
         )
         ->shouldBeCalledTimes(2);
 
-        $logger = $this->prophesize('Psr\Log\LoggerInterface');
+        $logger = $this->prophesize(LoggerInterface::class);
         $logger->info(
             Argument::exact(sprintf('[MaxMessages] Max messages have been reached (%d)', $maxMessages)),
             Argument::exact(['swarrot_processor' => 'max_messages'])

--- a/tests/Swarrot/Processor/MemoryLimit/MemoryLimitProcessorTest.php
+++ b/tests/Swarrot/Processor/MemoryLimit/MemoryLimitProcessorTest.php
@@ -5,38 +5,40 @@ namespace Swarrot\Processor\MemoryLimit;
 use PHPUnit\Framework\TestCase;
 use Prophecy\Argument;
 use Swarrot\Broker\Message;
+use Swarrot\Processor\ProcessorInterface;
+use Psr\Log\LoggerInterface;
 
 class MemoryLimitProcessorTest extends TestCase
 {
     public function test_it_is_initializable_without_a_logger()
     {
-        $processor = $this->prophesize('Swarrot\Processor\ProcessorInterface');
+        $processor = $this->prophesize(ProcessorInterface::class);
 
         $processor = new MemoryLimitProcessor($processor->reveal());
-        $this->assertInstanceOf('Swarrot\Processor\MemoryLimit\MemoryLimitProcessor', $processor);
+        $this->assertInstanceOf(MemoryLimitProcessor::class, $processor);
     }
 
     public function test_it_is_initializable_with_a_logger()
     {
-        $processor = $this->prophesize('Swarrot\Processor\ProcessorInterface');
-        $logger    = $this->prophesize('Psr\Log\LoggerInterface');
+        $processor = $this->prophesize(ProcessorInterface::class);
+        $logger    = $this->prophesize(LoggerInterface::class);
 
         $processor = new MemoryLimitProcessor($processor->reveal(), $logger->reveal());
-        $this->assertInstanceOf('Swarrot\Processor\MemoryLimit\MemoryLimitProcessor', $processor);
+        $this->assertInstanceOf(MemoryLimitProcessor::class, $processor);
     }
 
     public function test_delegate_processing()
     {
-        $processor = $this->prophesize('Swarrot\Processor\ProcessorInterface');
+        $processor = $this->prophesize(ProcessorInterface::class);
         $processor->process(
-            Argument::type('Swarrot\Broker\Message'),
+            Argument::type(Message::class),
             Argument::exact(array(
                 'memory_limit' => null,
             ))
         )
         ->shouldBeCalledTimes(1);
 
-        $logger = $this->prophesize('Psr\Log\LoggerInterface');
+        $logger = $this->prophesize(LoggerInterface::class);
 
         $message = new Message('body', array(), 1);
         $processor = new MemoryLimitProcessor(

--- a/tests/Swarrot/Processor/NewRelic/NewRelicProcessorTest.php
+++ b/tests/Swarrot/Processor/NewRelic/NewRelicProcessorTest.php
@@ -3,6 +3,7 @@
 namespace Swarrot\Processor\NewRelic;
 
 use PHPUnit\Framework\TestCase;
+use Swarrot\Processor\ProcessorInterface;
 use Symfony\Component\OptionsResolver\OptionsResolver;
 
 class NewRelicProcessorTest extends TestCase
@@ -10,7 +11,7 @@ class NewRelicProcessorTest extends TestCase
     public function testOptions()
     {
         $processor = new NewRelicProcessor(
-            $this->prophesize('Swarrot\Processor\ProcessorInterface')->reveal()
+            $this->prophesize(ProcessorInterface::class)->reveal()
         );
 
         $resolver = new OptionsResolver();

--- a/tests/Swarrot/Processor/RPC/RpcClientProcessorTest.php
+++ b/tests/Swarrot/Processor/RPC/RpcClientProcessorTest.php
@@ -4,39 +4,41 @@ namespace Swarrot\Processor\RPC;
 
 use PHPUnit\Framework\TestCase;
 use Prophecy\Argument;
+use Psr\Log\LoggerInterface;
 use Swarrot\Broker\Message;
+use Swarrot\Processor\ProcessorInterface;
 
 class RpcClientProcessorTest extends TestCase
 {
     public function test_it_is_initializable_without_a_logger()
     {
         $processor = new RpcClientProcessor();
-        $this->assertInstanceOf('Swarrot\\Processor\\RPC\\RpcClientProcessor', $processor);
+        $this->assertInstanceOf(RpcClientProcessor::class, $processor);
     }
 
     public function test_it_is_initializable_with_a_logger()
     {
-        $logger = $this->prophesize('Psr\\Log\\LoggerInterface');
+        $logger = $this->prophesize(LoggerInterface::class);
 
         $processor = new RpcClientProcessor(null, $logger->reveal());
-        $this->assertInstanceOf('Swarrot\\Processor\\RPC\\RpcClientProcessor', $processor);
+        $this->assertInstanceOf(RpcClientProcessor::class, $processor);
     }
 
     public function test_it_is_initializable_with_a_processor()
     {
-        $processor = $this->prophesize('Swarrot\\Processor\\ProcessorInterface');
+        $processor = $this->prophesize(ProcessorInterface::class);
 
         $processor = new RpcClientProcessor($processor->reveal());
-        $this->assertInstanceOf('Swarrot\\Processor\\RPC\\RpcClientProcessor', $processor);
+        $this->assertInstanceOf(RpcClientProcessor::class, $processor);
     }
 
     public function test_it_is_initializable_with_a_processor_and_a_logger()
     {
-        $processor = $this->prophesize('Swarrot\\Processor\\ProcessorInterface');
-        $logger = $this->prophesize('Psr\\Log\\LoggerInterface');
+        $processor = $this->prophesize(ProcessorInterface::class);
+        $logger = $this->prophesize(LoggerInterface::class);
 
         $processor = new RpcClientProcessor($processor->reveal(), $logger->reveal());
-        $this->assertInstanceOf('Swarrot\\Processor\\RPC\\RpcClientProcessor', $processor);
+        $this->assertInstanceOf(RpcClientProcessor::class, $processor);
     }
 
     public function test_it_should_sleep_if_no_correlation_id_set()
@@ -67,7 +69,7 @@ class RpcClientProcessorTest extends TestCase
     {
         $message = new Message(null, ['correlation_id' => 1]);
 
-        $processor = $this->prophesize('Swarrot\\Processor\\ProcessorInterface');
+        $processor = $this->prophesize(ProcessorInterface::class);
         $processor->process($message, ['rpc_client_correlation_id' => 1])->willReturn(true)->shouldBeCalled();
         $processor = new RpcClientProcessor($processor->reveal());
 

--- a/tests/Swarrot/Processor/RPC/RpcServerProcessorTest.php
+++ b/tests/Swarrot/Processor/RPC/RpcServerProcessorTest.php
@@ -4,34 +4,37 @@ namespace Swarrot\Processor\RPC;
 
 use PHPUnit\Framework\TestCase;
 use Prophecy\Argument;
+use Psr\Log\LoggerInterface;
 use Swarrot\Broker\Message;
+use Swarrot\Broker\MessagePublisher\MessagePublisherInterface;
+use Swarrot\Processor\ProcessorInterface;
 
 class RpcServerProcessorTest extends TestCase
 {
     public function test_it_is_initializable_without_a_logger()
     {
-        $processor        = $this->prophesize('Swarrot\\Processor\\ProcessorInterface');
-        $messagePublisher = $this->prophesize('Swarrot\\Broker\\MessagePublisher\\MessagePublisherInterface');
+        $processor        = $this->prophesize(ProcessorInterface::class);
+        $messagePublisher = $this->prophesize(MessagePublisherInterface::class);
 
         $processor = new RpcServerProcessor($processor->reveal(), $messagePublisher->reveal());
-        $this->assertInstanceOf('Swarrot\\Processor\\RPC\\RpcServerProcessor', $processor);
+        $this->assertInstanceOf(RpcServerProcessor::class, $processor);
     }
 
     public function test_it_is_initializable_with_a_logger()
     {
-        $processor        = $this->prophesize('Swarrot\\Processor\\ProcessorInterface');
-        $messagePublisher = $this->prophesize('Swarrot\\Broker\\MessagePublisher\\MessagePublisherInterface');
-        $logger           = $this->prophesize('Psr\\Log\\LoggerInterface');
+        $processor        = $this->prophesize(ProcessorInterface::class);
+        $messagePublisher = $this->prophesize(MessagePublisherInterface::class);
+        $logger           = $this->prophesize(LoggerInterface::class);
 
         $processor = new RpcServerProcessor($processor->reveal(), $messagePublisher->reveal(), $logger->reveal());
-        $this->assertInstanceOf('Swarrot\\Processor\\RPC\\RpcServerProcessor', $processor);
+        $this->assertInstanceOf(RpcServerProcessor::class, $processor);
     }
 
     /** @dataProvider noPropertiesProvider */
     public function test_it_should_do_an_early_return_if_no_adequate_properties(array $properties)
     {
-        $processor        = $this->prophesize('Swarrot\\Processor\\ProcessorInterface');
-        $messagePublisher = $this->prophesize('Swarrot\\Broker\\MessagePublisher\\MessagePublisherInterface');
+        $processor        = $this->prophesize(ProcessorInterface::class);
+        $messagePublisher = $this->prophesize(MessagePublisherInterface::class);
         $messagePublisher->publish()->shouldNotBeCalled();
 
         $processor = new RpcServerProcessor($processor->reveal(), $messagePublisher->reveal());
@@ -54,10 +57,10 @@ class RpcServerProcessorTest extends TestCase
     {
         $message = new Message('', ['reply_to' => 'foo', 'correlation_id' => 42]);
 
-        $processor = $this->prophesize('Swarrot\\Processor\\ProcessorInterface');
+        $processor = $this->prophesize(ProcessorInterface::class);
         $processor->process($message, [])->willReturn('bar');
 
-        $messagePublisher = $this->prophesize('Swarrot\\Broker\\MessagePublisher\\MessagePublisherInterface');
+        $messagePublisher = $this->prophesize(MessagePublisherInterface::class);
         $messagePublisher->publish(Argument::that(function ($argument) {
             return $argument instanceof Message && 'bar' === $argument->getBody() && array_key_exists('correlation_id', $argument->getProperties());
         }), Argument::is('foo'))->shouldBeCalled();

--- a/tests/Swarrot/Processor/Retry/RetryProcessorTest.php
+++ b/tests/Swarrot/Processor/Retry/RetryProcessorTest.php
@@ -4,36 +4,39 @@ namespace Swarrot\Processor\Retry;
 
 use PHPUnit\Framework\TestCase;
 use Prophecy\Argument;
+use Psr\Log\LoggerInterface;
 use Psr\Log\LogLevel;
 use Swarrot\Broker\Message;
+use Swarrot\Broker\MessagePublisher\MessagePublisherInterface;
+use Swarrot\Processor\ProcessorInterface;
 use Symfony\Component\OptionsResolver\OptionsResolver;
 
 class RetryProcessorTest extends TestCase
 {
     public function test_it_is_initializable_without_a_logger()
     {
-        $processor        = $this->prophesize('Swarrot\Processor\ProcessorInterface');
-        $messagePublisher = $this->prophesize('Swarrot\Broker\MessagePublisher\MessagePublisherInterface');
+        $processor        = $this->prophesize(ProcessorInterface::class);
+        $messagePublisher = $this->prophesize(MessagePublisherInterface::class);
 
         $processor = new RetryProcessor($processor->reveal(), $messagePublisher->reveal());
-        $this->assertInstanceOf('Swarrot\Processor\Retry\RetryProcessor', $processor);
+        $this->assertInstanceOf(RetryProcessor::class, $processor);
     }
 
     public function test_it_is_initializable_with_a_logger()
     {
-        $processor        = $this->prophesize('Swarrot\Processor\ProcessorInterface');
-        $messagePublisher = $this->prophesize('Swarrot\Broker\MessagePublisher\MessagePublisherInterface');
-        $logger           = $this->prophesize('Psr\Log\LoggerInterface');
+        $processor        = $this->prophesize(ProcessorInterface::class);
+        $messagePublisher = $this->prophesize(MessagePublisherInterface::class);
+        $logger           = $this->prophesize(LoggerInterface::class);
 
         $processor = new RetryProcessor($processor->reveal(), $messagePublisher->reveal(), $logger->reveal());
-        $this->assertInstanceOf('Swarrot\Processor\Retry\RetryProcessor', $processor);
+        $this->assertInstanceOf(RetryProcessor::class, $processor);
     }
 
     public function test_it_should_return_result_when_all_is_right()
     {
-        $processor        = $this->prophesize('Swarrot\Processor\ProcessorInterface');
-        $messagePublisher = $this->prophesize('Swarrot\Broker\MessagePublisher\MessagePublisherInterface');
-        $logger           = $this->prophesize('Psr\Log\LoggerInterface');
+        $processor        = $this->prophesize(ProcessorInterface::class);
+        $messagePublisher = $this->prophesize(MessagePublisherInterface::class);
+        $logger           = $this->prophesize(LoggerInterface::class);
 
         $message = new Message('body', array(), 1);
 
@@ -49,9 +52,9 @@ class RetryProcessorTest extends TestCase
 
     public function test_it_should_republished_message_when_an_exception_occurred()
     {
-        $processor        = $this->prophesize('Swarrot\Processor\ProcessorInterface');
-        $messagePublisher = $this->prophesize('Swarrot\Broker\MessagePublisher\MessagePublisherInterface');
-        $logger           = $this->prophesize('Psr\Log\LoggerInterface');
+        $processor        = $this->prophesize(ProcessorInterface::class);
+        $messagePublisher = $this->prophesize(MessagePublisherInterface::class);
+        $logger           = $this->prophesize(LoggerInterface::class);
 
         $message = new Message('body', array(), 1);
         $options = array(
@@ -70,7 +73,7 @@ class RetryProcessorTest extends TestCase
         ;
         $messagePublisher
             ->publish(
-                Argument::type('Swarrot\Broker\Message'),
+                Argument::type(Message::class),
                 Argument::exact('key_1')
             )
             ->willReturn(null)
@@ -86,9 +89,9 @@ class RetryProcessorTest extends TestCase
 
     public function test_it_should_republished_message_with_incremented_attempts()
     {
-        $processor        = $this->prophesize('Swarrot\Processor\ProcessorInterface');
-        $messagePublisher = $this->prophesize('Swarrot\Broker\MessagePublisher\MessagePublisherInterface');
-        $logger           = $this->prophesize('Psr\Log\LoggerInterface');
+        $processor        = $this->prophesize(ProcessorInterface::class);
+        $messagePublisher = $this->prophesize(MessagePublisherInterface::class);
+        $logger           = $this->prophesize(LoggerInterface::class);
 
         $message = new Message('body', array('headers' => array('swarrot_retry_attempts' => 1)), 1);
 
@@ -129,9 +132,9 @@ class RetryProcessorTest extends TestCase
 
     public function test_it_should_throw_exception_if_max_attempts_is_reached()
     {
-        $processor        = $this->prophesize('Swarrot\Processor\ProcessorInterface');
-        $messagePublisher = $this->prophesize('Swarrot\Broker\MessagePublisher\MessagePublisherInterface');
-        $logger           = $this->prophesize('Psr\Log\LoggerInterface');
+        $processor        = $this->prophesize(ProcessorInterface::class);
+        $messagePublisher = $this->prophesize(MessagePublisherInterface::class);
+        $logger           = $this->prophesize(LoggerInterface::class);
 
         $message = new Message('body', array('headers' => array('swarrot_retry_attempts' => 3)), 1);
         $options = array(
@@ -150,7 +153,7 @@ class RetryProcessorTest extends TestCase
         ;
         $messagePublisher
             ->publish(
-                Argument::type('Swarrot\Broker\Message'),
+                Argument::type(Message::class),
                 Argument::exact('key_1')
             )
             ->shouldNotBeCalled()
@@ -164,8 +167,8 @@ class RetryProcessorTest extends TestCase
 
     public function test_it_should_return_a_valid_array_of_option()
     {
-        $processor        = $this->prophesize('Swarrot\Processor\ProcessorInterface');
-        $messagePublisher = $this->prophesize('Swarrot\Broker\MessagePublisher\MessagePublisherInterface');
+        $processor        = $this->prophesize(ProcessorInterface::class);
+        $messagePublisher = $this->prophesize(MessagePublisherInterface::class);
 
         $processor = new RetryProcessor($processor->reveal(), $messagePublisher->reveal());
 
@@ -186,9 +189,9 @@ class RetryProcessorTest extends TestCase
 
     public function test_it_should_keep_original_message_properties()
     {
-        $processor        = $this->prophesize('Swarrot\Processor\ProcessorInterface');
-        $messagePublisher = $this->prophesize('Swarrot\Broker\MessagePublisher\MessagePublisherInterface');
-        $logger           = $this->prophesize('Psr\Log\LoggerInterface');
+        $processor        = $this->prophesize(ProcessorInterface::class);
+        $messagePublisher = $this->prophesize(MessagePublisherInterface::class);
+        $logger           = $this->prophesize(LoggerInterface::class);
 
         $message = new Message('body', array('delivery_mode' => 2, 'app_id' => 'applicationId', 'headers' => array('swarrot_retry_attempts' => 1)), 1);
 
@@ -230,9 +233,9 @@ class RetryProcessorTest extends TestCase
 
     public function test_it_should_keep_original_message_headers()
     {
-        $processor        = $this->prophesize('Swarrot\Processor\ProcessorInterface');
-        $messagePublisher = $this->prophesize('Swarrot\Broker\MessagePublisher\MessagePublisherInterface');
-        $logger           = $this->prophesize('Psr\Log\LoggerInterface');
+        $processor        = $this->prophesize(ProcessorInterface::class);
+        $messagePublisher = $this->prophesize(MessagePublisherInterface::class);
+        $logger           = $this->prophesize(LoggerInterface::class);
 
         $message = new Message('body', array('headers' => array(
             'string' => 'foo',
@@ -276,9 +279,9 @@ class RetryProcessorTest extends TestCase
 
     public function test_it_should_log_a_warning_by_default_when_an_exception_occurred()
     {
-        $processor        = $this->prophesize('Swarrot\Processor\ProcessorInterface');
-        $messagePublisher = $this->prophesize('Swarrot\Broker\MessagePublisher\MessagePublisherInterface');
-        $logger           = $this->prophesize('Psr\Log\LoggerInterface');
+        $processor        = $this->prophesize(ProcessorInterface::class);
+        $messagePublisher = $this->prophesize(MessagePublisherInterface::class);
+        $logger           = $this->prophesize(LoggerInterface::class);
         $exception        = new \BadMethodCallException();
 
         $message = new Message('body', array(), 1);
@@ -318,9 +321,9 @@ class RetryProcessorTest extends TestCase
 
     public function test_it_should_log_a_custom_log_level_when_an_exception_occurred()
     {
-        $processor        = $this->prophesize('Swarrot\Processor\ProcessorInterface');
-        $messagePublisher = $this->prophesize('Swarrot\Broker\MessagePublisher\MessagePublisherInterface');
-        $logger           = $this->prophesize('Psr\Log\LoggerInterface');
+        $processor        = $this->prophesize(ProcessorInterface::class);
+        $messagePublisher = $this->prophesize(MessagePublisherInterface::class);
+        $logger           = $this->prophesize(LoggerInterface::class);
         $exception        = new \BadMethodCallException();
 
         $message = new Message('body', array(), 1);
@@ -362,9 +365,9 @@ class RetryProcessorTest extends TestCase
 
     public function test_it_should_log_a_custom_log_level_when_a_child_exception_occurred()
     {
-        $processor        = $this->prophesize('Swarrot\Processor\ProcessorInterface');
-        $messagePublisher = $this->prophesize('Swarrot\Broker\MessagePublisher\MessagePublisherInterface');
-        $logger           = $this->prophesize('Psr\Log\LoggerInterface');
+        $processor        = $this->prophesize(ProcessorInterface::class);
+        $messagePublisher = $this->prophesize(MessagePublisherInterface::class);
+        $logger           = $this->prophesize(LoggerInterface::class);
         $exception        = new \BadMethodCallException();
 
         $message = new Message('body', array(), 1);
@@ -406,9 +409,9 @@ class RetryProcessorTest extends TestCase
 
     public function test_it_should_log_a_warning_by_default_if_max_attempts_is_reached()
     {
-        $processor        = $this->prophesize('Swarrot\Processor\ProcessorInterface');
-        $messagePublisher = $this->prophesize('Swarrot\Broker\MessagePublisher\MessagePublisherInterface');
-        $logger           = $this->prophesize('Psr\Log\LoggerInterface');
+        $processor        = $this->prophesize(ProcessorInterface::class);
+        $messagePublisher = $this->prophesize(MessagePublisherInterface::class);
+        $logger           = $this->prophesize(LoggerInterface::class);
         $exception        = new \BadMethodCallException();
 
         $message = new Message('body', array('headers' => array('swarrot_retry_attempts' => 3)), 1);
@@ -447,9 +450,9 @@ class RetryProcessorTest extends TestCase
 
     public function test_it_should_log_a_custom_log_level_if_max_attempts_is_reached()
     {
-        $processor        = $this->prophesize('Swarrot\Processor\ProcessorInterface');
-        $messagePublisher = $this->prophesize('Swarrot\Broker\MessagePublisher\MessagePublisherInterface');
-        $logger           = $this->prophesize('Psr\Log\LoggerInterface');
+        $processor        = $this->prophesize(ProcessorInterface::class);
+        $messagePublisher = $this->prophesize(MessagePublisherInterface::class);
+        $logger           = $this->prophesize(LoggerInterface::class);
         $exception        = new \BadMethodCallException();
 
         $message = new Message('body', array('headers' => array('swarrot_retry_attempts' => 3)), 1);
@@ -490,9 +493,9 @@ class RetryProcessorTest extends TestCase
 
     public function test_it_should_log_a_custom_log_level_if_max_attempts_is_reached_for_child_exception()
     {
-        $processor        = $this->prophesize('Swarrot\Processor\ProcessorInterface');
-        $messagePublisher = $this->prophesize('Swarrot\Broker\MessagePublisher\MessagePublisherInterface');
-        $logger           = $this->prophesize('Psr\Log\LoggerInterface');
+        $processor        = $this->prophesize(ProcessorInterface::class);
+        $messagePublisher = $this->prophesize(MessagePublisherInterface::class);
+        $logger           = $this->prophesize(LoggerInterface::class);
         $exception        = new \BadMethodCallException();
 
         $message = new Message('body', array('headers' => array('swarrot_retry_attempts' => 3)), 1);

--- a/tests/Swarrot/Processor/Sentry/SentryProcessorTest.php
+++ b/tests/Swarrot/Processor/Sentry/SentryProcessorTest.php
@@ -6,13 +6,15 @@ use Swarrot\Processor\Sentry\SentryProcessor;
 use PHPUnit\Framework\TestCase;
 use Prophecy\Argument;
 use Swarrot\Broker\Message;
+use Swarrot\Processor\ProcessorInterface;
+use Raven_Client;
 
 class SentryProcessorTest extends TestCase
 {
     public function test_it_should_return_void_when_no_exception_is_thrown()
     {
-        $processor       = $this->prophesize('Swarrot\Processor\ProcessorInterface');
-        $sentryClient    = $this->prophesize('Raven_Client');
+        $processor       = $this->prophesize(ProcessorInterface::class);
+        $sentryClient    = $this->prophesize(Raven_Client::class);
 
         $message = new Message('my_body', [], 1);
         $processor = new SentryProcessor($processor->reveal(), $sentryClient->reveal());
@@ -24,8 +26,8 @@ class SentryProcessorTest extends TestCase
 
     public function test_it_should_capture_when_an_exception_is_thrown()
     {
-        $processor       = $this->prophesize('Swarrot\Processor\ProcessorInterface');
-        $sentryClient    = $this->prophesize('Raven_Client');
+        $processor       = $this->prophesize(ProcessorInterface::class);
+        $sentryClient    = $this->prophesize(Raven_Client::class);
 
         $message = new Message('my_body', [], 1);
         $options = [

--- a/tests/Swarrot/Processor/SignalHandler/SignalHandlerProcessorTest.php
+++ b/tests/Swarrot/Processor/SignalHandler/SignalHandlerProcessorTest.php
@@ -5,30 +5,32 @@ namespace Swarrot\Processor\SignalHandler;
 use PHPUnit\Framework\TestCase;
 use Prophecy\Argument;
 use Swarrot\Broker\Message;
+use Swarrot\Processor\ProcessorInterface;
+use Psr\Log\LoggerInterface;
 
 class SignalHandlerProcessorTest extends TestCase
 {
     public function test_it_is_initializable_without_a_logger()
     {
-        $processor       = $this->prophesize('Swarrot\Processor\ProcessorInterface');
+        $processor       = $this->prophesize(ProcessorInterface::class);
 
         $processor = new SignalHandlerProcessor($processor->reveal());
-        $this->assertInstanceOf('Swarrot\Processor\SignalHandler\SignalHandlerProcessor', $processor);
+        $this->assertInstanceOf(SignalHandlerProcessor::class, $processor);
     }
 
     public function test_it_is_initializable_with_a_logger()
     {
-        $processor       = $this->prophesize('Swarrot\Processor\ProcessorInterface');
-        $logger          = $this->prophesize('Psr\Log\LoggerInterface');
+        $processor       = $this->prophesize(ProcessorInterface::class);
+        $logger          = $this->prophesize(LoggerInterface::class);
 
         $processor = new SignalHandlerProcessor($processor->reveal(), $logger->reveal());
-        $this->assertInstanceOf('Swarrot\Processor\SignalHandler\SignalHandlerProcessor', $processor);
+        $this->assertInstanceOf(SignalHandlerProcessor::class, $processor);
     }
 
     public function test_it_should_return_void_when_no_exception_is_thrown()
     {
-        $processor       = $this->prophesize('Swarrot\Processor\ProcessorInterface');
-        $logger          = $this->prophesize('Psr\Log\LoggerInterface');
+        $processor       = $this->prophesize(ProcessorInterface::class);
+        $logger          = $this->prophesize(LoggerInterface::class);
 
         $message = new Message('body', array(), 1);
         $processor = new SignalHandlerProcessor($processor->reveal(), $logger->reveal());
@@ -37,8 +39,8 @@ class SignalHandlerProcessorTest extends TestCase
 
     public function test_it_should_throw_an_exception_after_consecutive_failed()
     {
-        $processor       = $this->prophesize('Swarrot\Processor\ProcessorInterface');
-        $logger          = $this->prophesize('Psr\Log\LoggerInterface');
+        $processor       = $this->prophesize(ProcessorInterface::class);
+        $logger          = $this->prophesize(LoggerInterface::class);
 
         $message = new Message('body', array(), 1);
 

--- a/tests/Swarrot/Processor/Stack/StackedProcessorTest.php
+++ b/tests/Swarrot/Processor/Stack/StackedProcessorTest.php
@@ -5,15 +5,19 @@ namespace Swarrot\Processor\Stack;
 use PHPUnit\Framework\TestCase;
 use Prophecy\Argument;
 use Swarrot\Broker\Message;
+use Swarrot\Processor\ProcessorInterface;
+use Swarrot\Processor\InitializableInterface;
+use Swarrot\Processor\TerminableInterface;
+use Swarrot\Processor\SleepyInterface;
 
 class StackedProcessorTest extends TestCase
 {
     public function test_it_is_initializable()
     {
-        $p1  = $this->prophesize('Swarrot\Processor\ProcessorInterface');
-        $p2  = $this->prophesize('Swarrot\Processor\InitializableInterface');
-        $p3  = $this->prophesize('Swarrot\Processor\TerminableInterface');
-        $p4  = $this->prophesize('Swarrot\Processor\SleepyInterface');
+        $p1  = $this->prophesize(ProcessorInterface::class);
+        $p2  = $this->prophesize(InitializableInterface::class);
+        $p3  = $this->prophesize(TerminableInterface::class);
+        $p4  = $this->prophesize(SleepyInterface::class);
 
         $stackedProcessor = new StackedProcessor(
             $p1->reveal(), array(
@@ -23,24 +27,24 @@ class StackedProcessorTest extends TestCase
             )
         );
 
-        $this->assertInstanceOf('Swarrot\Processor\Stack\StackedProcessor', $stackedProcessor);
+        $this->assertInstanceOf(StackedProcessor::class, $stackedProcessor);
     }
 
     public function test_it_is_callable()
     {
-        $p1  = $this->prophesize('Swarrot\Processor\ProcessorInterface');
-        $p2  = $this->prophesize('Swarrot\Processor\InitializableInterface');
-        $p3  = $this->prophesize('Swarrot\Processor\TerminableInterface');
-        $p4  = $this->prophesize('Swarrot\Processor\SleepyInterface');
+        $p1  = $this->prophesize(ProcessorInterface::class);
+        $p2  = $this->prophesize(InitializableInterface::class);
+        $p3  = $this->prophesize(TerminableInterface::class);
+        $p4  = $this->prophesize(SleepyInterface::class);
 
         $p2->initialize(Argument::type('array'))->willReturn(null);
         $p3->terminate(Argument::type('array'))->willReturn(null);
         $p4->sleep(Argument::type('array'))->willReturn(null);
 
-        $p1->process(Argument::type('Swarrot\Broker\Message'), Argument::type('array'))->willReturn(null);
-        $p2->process(Argument::type('Swarrot\Broker\Message'), Argument::type('array'))->willReturn(null);
-        $p3->process(Argument::type('Swarrot\Broker\Message'), Argument::type('array'))->willReturn(null);
-        $p4->process(Argument::type('Swarrot\Broker\Message'), Argument::type('array'))->willReturn(null);
+        $p1->process(Argument::type(Message::class), Argument::type('array'))->willReturn(null);
+        $p2->process(Argument::type(Message::class), Argument::type('array'))->willReturn(null);
+        $p3->process(Argument::type(Message::class), Argument::type('array'))->willReturn(null);
+        $p4->process(Argument::type(Message::class), Argument::type('array'))->willReturn(null);
 
         $stackedProcessor = new StackedProcessor(
             $p1->reveal(), array(
@@ -62,10 +66,10 @@ class StackedProcessorTest extends TestCase
 
     public function test_sleep_return_false_if_at_least_a_processor_return_false()
     {
-        $p1  = $this->prophesize('Swarrot\Processor\SleepyInterface');
-        $p2  = $this->prophesize('Swarrot\Processor\SleepyInterface');
-        $p3  = $this->prophesize('Swarrot\Processor\SleepyInterface');
-        $p4  = $this->prophesize('Swarrot\Processor\SleepyInterface');
+        $p1  = $this->prophesize(SleepyInterface::class);
+        $p2  = $this->prophesize(SleepyInterface::class);
+        $p3  = $this->prophesize(SleepyInterface::class);
+        $p4  = $this->prophesize(SleepyInterface::class);
 
         $p2->sleep(Argument::type('array'))->willReturn(true);
         $p3->sleep(Argument::type('array'))->willReturn(true);


### PR DESCRIPTION
The latest tests use the syntax ":: class" but the old still use the class name as a string.

To be consistent, I modified all the tests to use the ":: class" syntax