### PR TITLE
[DRAFT][Need feedbacks] Consume POC

### DIFF
--- a/src/Swarrot/Broker/MessageProvider/MessageProviderInterface.php
+++ b/src/Swarrot/Broker/MessageProvider/MessageProviderInterface.php
@@ -14,6 +14,14 @@ interface MessageProviderInterface
     public function get();
 
     /**
+     * consume
+     *
+     * @param string $consumerTag Identify the consumer for the rabbitmq-server
+     * @param callable $callback A callback receiving a Swarrot\Broker\Message instance on consumption
+     */
+    public function consume($consumerTag, callable $callback);
+
+    /**
      * ack.
      *
      * @param Message $message

--- a/src/Swarrot/Broker/MessageProvider/PeclPackageMessageProvider.php
+++ b/src/Swarrot/Broker/MessageProvider/PeclPackageMessageProvider.php
@@ -22,6 +22,48 @@ class PeclPackageMessageProvider implements MessageProviderInterface
     /**
      * {@inheritdoc}
      */
+    public function consume($consumerTag, callable $callback)
+    {
+
+        $this->queue->consume(function(\AMQPEnvelope $envelope) use ($callback) {
+
+            if (!$envelope) {
+                throw new \Exception('No envelope');
+            }
+
+            return !$callback(new Message(
+                $envelope->getBody(),
+                array(
+                    'content_type' => $envelope->getContentType(),
+                    'routing_key' => $envelope->getRoutingKey(),
+                    'delivery_tag' => $envelope->getDeliveryTag(),
+                    'delivery_mode' => $envelope->getDeliveryMode(),
+                    'exchange_name' => $envelope->getExchangeName(),
+                    'is_redelivery' => $envelope->isRedelivery(),
+                    'content_encoding' => $envelope->getContentEncoding(),
+                    'type' => $envelope->getType(),
+                    'timestamp' => $envelope->getTimeStamp(),
+                    'priority' => $envelope->getPriority(),
+                    'expiration' => $envelope->getExpiration(),
+                    'app_id' => $envelope->getAppId(),
+                    'message_id' => $envelope->getMessageId(),
+                    'reply_to' => $envelope->getReplyTo(),
+                    'correlation_id' => $envelope->getCorrelationId(),
+                    'headers' => $envelope->getHeaders(),
+                    'user_id' => $envelope->getUserId(),
+                    'cluster_id' => 0,
+                    'channel' => '',
+                    'consumer_tag' => '',
+                ),
+                $envelope->getDeliveryTag()
+            ));
+
+        }, AMQP_NOPARAM, $consumerTag);
+    }
+
+    /**
+     * {@inheritdoc}
+     */
     public function get()
     {
         $envelope = $this->queue->get();


### PR DESCRIPTION
## Context

In Go or Javascript I've notice that you can see how many consumers are connected, what are their names and with which arguments they have been popped

<img width="805" alt="capture d ecran 2018-01-09 a 15 20 38" src="https://user-images.githubusercontent.com/1516110/34766574-28a5cf74-f5f5-11e7-8eba-320a07c1c60f.png">

After searching a bit I understood that we can also achieve it in PHP and with swarrot, by using the consume method instead of the get method.

## Proposition

So my suggestion would be to add the possibility to choose either the consume or the get method when consuming.

Attached code is just an ugly draft to test it. I'd like to know if someone see an issue with this idea before going further ?

|  | Get | Consume |
| ---  | --- | --- |
| Benefits | Non-Blocking | Long polling, Faster, show consumer in RMQ UI |
| Drawbacks | Short polling, Treatments in SleepyInterface load the host | Blocking |

Exemple

<img width="1090" alt="capture d ecran 2018-01-10 a 21 19 43" src="https://user-images.githubusercontent.com/1516110/34793547-0728e686-f64c-11e7-8661-ba0334d6c5d1.png">

## Measures

Blackfire profiles
- Get : https://blackfire.io/profiles/d63a7eef-fe40-476b-8850-d190334b6362/graph
- Consume  : https://blackfire.io/profiles/dd9bbb8f-f7e5-4aa7-83d9-bd036b74793d/graph

Consume seems slightly more performant (~10%) than get
```
vagrant@local:~/www/lafourchette-b2c-crm(master)$ time app/console swarrot:consume:customer_consumer --max-messages=1000 --method=get

real	0m7.405s
user	0m2.476s
sys	0m0.228s
vagrant@local:~/www/lafourchette-b2c-crm(master)$ time app/console swarrot:consume:customer_consumer --max-messages=1000 --method=consume

real	0m5.400s
user	0m1.952s
sys	0m0.172s
vagrant@local:~/www/lafourchette-b2c-crm(master)$ time app/console swarrot:consume:customer_consumer --max-messages=10000 --method=get

real	1m0.685s
user	0m20.997s
sys	0m1.448s
vagrant@local:~/www/lafourchette-b2c-crm(master)$ time app/console swarrot:consume:customer_consumer --max-messages=10000 --method=consume

real	0m53.869s
user	0m19.749s
sys	0m1.196s
```