### PR TITLE
[ACKProcessor] Add queue name in log context

### DIFF
--- a/src/Swarrot/Processor/Ack/AckProcessor.php
+++ b/src/Swarrot/Processor/Ack/AckProcessor.php
@@ -52,6 +52,7 @@ class AckProcessor implements ConfigurableInterface
                 '[Ack] Message #'.$message->getId().' has been correctly ack\'ed',
                 [
                     'swarrot_processor' => 'ack',
+                    'queue_name' => $this->messageProvider->getQueueName(),
                 ]
             );
 
@@ -94,6 +95,7 @@ class AckProcessor implements ConfigurableInterface
             ),
             [
                 'swarrot_processor' => 'ack',
+                'queue_name' => $this->messageProvider->getQueueName(),
                 'exception' => $exception,
             ]
         );


### PR DESCRIPTION
Hi,

IMO it could be great to have such information in the log context
What do you think?
Also what do you think about rewriting all log message so they are invaraible, and moving variable(s) to the context?

Thank you