### PR TITLE
[XDeathProcessor] Add XDeath max count and max lifetime processor

### DIFF
--- a/README.md
+++ b/README.md
@@ -162,6 +162,8 @@ if ($message = $messageProvider->get()) {
 * [RPC related processors](src/Swarrot/Processor/RPC) (thanks to [Baptiste Clavié](https://github.com/Taluu))
 * [SentryProcessor](src/Swarrot/Processor/Sentry) (thanks to [Floran Brutel](https://github.com/notFloran))
 * [SignalHandlerProcessor](src/Swarrot/Processor/SignalHandler)
+* [XDeathMaxCountProcessor](src/Swarrot/Processor/XDeath) (thanks to [Anthony Moutte](https://github.com/instabledesign))
+* [XDeathMaxLifetimeProcessor](src/Swarrot/Processor/XDeath) (thanks to [Anthony Moutte](https://github.com/instabledesign))
 
 ### Create your own processor
 

--- a/examples/03-x-death-count.php
+++ b/examples/03-x-death-count.php
@@ -1,0 +1,87 @@
+<?php
+
+/**
+ * In this example you will see how XDeathMaxCountProcessor work.
+ *
+ * Prerequis
+ * First let's create the delaying exchange+queue
+ *
+ * Create an exchange `waiting_5` (type: `topic`)
+ * Create an queue `waiting_5` (x-dead-letter-exchange: ``, x-message-ttl: `5000`)
+ * Bind the exchange `waiting_5` to the queue `waiting_5` with routing_key `#`
+ *
+ * And then create the simple global queue.
+ *
+ * Create an queue `global` with (x-dead-letter-exchange: `waiting_5`, x-dead-letter-routing-key: `global`)
+ *
+ * Run this page and send manually a message
+ */
+require_once __DIR__.'/../vendor/autoload.php';
+
+use Swarrot\Consumer;
+use Swarrot\Broker\Message;
+use Swarrot\Processor\ProcessorInterface;
+use Swarrot\Broker\MessageProvider\PeclPackageMessageProvider;
+
+class FailProcessor implements ProcessorInterface
+{
+    public function process(Message $message, array $options)
+    {
+        printf("Fail processor consume message #%d\n", $message->getId());
+
+        throw new \Exception('This is my process exception.');
+    }
+}
+
+class PrintLogger extends \Psr\Log\AbstractLogger
+{
+    public function log($level, $message, array $context = array())
+    {
+        printf("[Log %s] %s\n", $level, $message);
+    }
+}
+
+$printLogger = new PrintLogger();
+
+$connection = new \AMQPConnection();
+$connection->connect();
+$channel = new \AMQPChannel($connection);
+$queue = new \AMQPQueue($channel);
+$queue->setName('global');
+
+$messageProvider = new PeclPackageMessageProvider($queue);
+$stack = (new \Swarrot\Processor\Stack\Builder())
+    ->push('\Swarrot\Processor\Ack\AckProcessor', $messageProvider, $printLogger)
+    ->push(
+        '\Swarrot\Processor\XDeath\XDeathMaxCountProcessor',
+        'global',
+        function ($e, $message, $options) {
+            if (end($message->getProperties()['headers']['x-death'])['count'] > 5) {
+                printf("XDeathMaxCountProcessor callback executed. Not rethrow original exception\n");
+                // when you return false it not rethrow the catched exception
+                return false;
+            }
+
+            printf("XDeathMaxCountProcessor callback executed. Rethrow original exception\n");
+            // when you return null it rethrow the catched exception
+            return;
+        },
+        $printLogger
+    );
+
+$consumer = new Consumer(
+    $messageProvider,
+    $stack->resolve(new FailProcessor()),
+    null,
+    $printLogger
+);
+
+echo '<pre>';
+try {
+    $consumer->consume([
+        'x_death_max_count' => 3,
+    ]);
+} catch (\Exception $exception) {
+    printf("[%s] %s\n", get_class($exception), $exception->getMessage());
+}
+echo '</pre>';

--- a/src/Swarrot/Processor/XDeath/README.md
+++ b/src/Swarrot/Processor/XDeath/README.md
@@ -1,0 +1,103 @@
+# XDeathMaxCountProcessor
+
+XDeathMaxCountProcessor is a [swarrot](https://github.com/swarrot/swarrot) processor.
+Its goal is to execute a callback when x-death max count reached in order to kill poison message.
+
+This is a very different approach than RetryProcessor because there is no software clone message republish.
+This processor use the native rabbitmq x-death functionnality.
+
+## Configuration
+
+|Key                                  |Default|Description                                                                  |
+|:-----------------------------------:|:-----:|-----------------------------------------------------------------------------|
+|x_death_max_count                    |300    |The number of attempts before callback.
+|x_death_max_count_log_levels_map     |[]     |Map of classes to a log level when retry. (Warning by default)               |
+|x_death_max_count_fail_log_levels_map|[]     |Map of classes to a log level when all retries failed. (Warning by default)  |
+
+## How it works
+
+When your processor throw an exception (= failed to process a message), the
+XDeathMaxCount Processor will catch it and execute the callback if the message header x-death count
+exceed the `x_death_max_count`.
+
+/!\ Caution ! If your callback returns null, the exception will be rethrown.
+
+## Real example
+
+Let's say you want to consume a queue named `mail`. You would like to have 3
+retries if the mail is not sent correctly. Each retry was separate by 30 seconds.
+
+First let's create the delaying exchange+queue 
+
+* Create an exchange `waiting_30` (type: `topic`)
+* Create an queue `waiting_30` (x-dead-letter-exchange: ` `, x-message-ttl: `30000`)
+* Bind the exchange `waiting_30` to the queue `waiting_30` with routing_key `#`
+
+And then create the simple mail workflow.
+
+* Create an exchange `mail` (type: `direct`)
+* Create an queue `queue_mail` with (x-dead-letter-exchange: `waiting_30`, x-dead-letter-routing-key: `queue_mail`)
+* Bind the exchange `mail` to the queue `queue_mail` with routing_key `queue_mail`
+
+You must use the AckProcessor (or nack the message by yourself).
+
+Once this configuration is done, when an exception is thrown, the
+AckProcessor will nack the message and rabbitmq will append or increase message header
+x-death count. This x-death header is the message trace when the message was `reject` or `expired` by a queue.
+So the message was reject to exchange `waiting_30` and route to queue `waiting_30`.
+After 30 seconds the queue `expire` the message and move it to AMQP default exchange
+and route directly to queue `queue_mail`.
+If your consumer throw exception 3 times then the XDeathMaxCount will execute the configured callback 
+and not rethrow the exception in order to let the Ack processor ack the message to stop retrying it.
+
+
+# XDeathMaxLifetimeProcessor
+
+XDeathMaxLifetimeProcessor is a [swarrot](https://github.com/swarrot/swarrot) processor.
+Its goal is to execute a callback when x-death time exceed max lifetime in order to kill poison message.
+
+This is a very different approach than RetryProcessor because there is no software clone message republish.
+This processor use the native rabbitmq x-death functionnality.
+
+## Configuration
+
+|Key                                     |Default|Description                                                                  |
+|:--------------------------------------:|:-----:|-----------------------------------------------------------------------------|
+|x_death_max_lifetime                    |3600   |The number seconds before callback.
+|x_death_max_lifetime_log_levels_map     |[]     |Map of classes to a log level when retry. (Warning by default)               |
+|x_death_max_lifetime_fail_log_levels_map|[]     |Map of classes to a log level when all retries failed. (Warning by default)  |
+
+## How it works
+
+When your processor throw an exception (= failed to process a message), the
+XDeathMaxLifetime Processor will catch it and execute the callback if the message header x-death time
+exceed the `x_death_max_lifetime`.
+
+/!\ Caution ! If your callback returns null, the exception will be rethrown.
+
+## Real example
+
+Let's say you want to consume a queue named `mail`. You would like to
+retry during 1 hour if the mail is not sent correctly. Each retry was separate by 30 seconds.
+
+First let's create the delaying exchange+queue 
+
+* Create an exchange `waiting_30` (type: `topic`)
+* Create an queue `waiting_30` (x-dead-letter-exchange: ` `, x-message-ttl: `30000`)
+
+And then create the simple mail workflow.
+
+* Create an exchange `mail` (type: `direct`)
+* Create an queue `queue_mail` with (x-dead-letter-exchange: `waiting_30`, x-dead-letter-routing-key: `queue_mail`)
+* Bind the exchange `mail` to the queue `queue_mail` with routing_key `queue_mail`
+
+You must use the AckProcessor (or nack the message by yourself).
+
+Once this configuration is done, when an exception is thrown, the
+AckProcessor will nack the message and rabbitmq will append x-death time header (with timestamp). 
+This x-death header is the message trace when the message was `reject` or `expired` by a queue.
+So the message was reject to exchange `waiting_30` and route to queue `waiting_30`.
+After 30 seconds the queue `expire` the message and move it to AMQP default exchange
+and route directly to queue `queue_mail`.
+After 1 hour if your consumer throw exception then the XDeathMaxLifetime will execute the configured callback 
+and not rethrow the exception in order to let the Ack processor ack the message to stop retrying it.

--- a/src/Swarrot/Processor/XDeath/XDeathMaxCountProcessor.php
+++ b/src/Swarrot/Processor/XDeath/XDeathMaxCountProcessor.php
@@ -1,0 +1,176 @@
+<?php
+
+namespace Swarrot\Processor\XDeath;
+
+use PhpAmqpLib\Wire\AMQPArray;
+use Psr\Log\LoggerInterface;
+use Psr\Log\LogLevel;
+use Psr\Log\NullLogger;
+use Swarrot\Broker\Message;
+use Swarrot\Processor\ProcessorInterface;
+use Swarrot\Processor\ConfigurableInterface;
+use Symfony\Component\OptionsResolver\OptionsResolver;
+
+class XDeathMaxCountProcessor implements ConfigurableInterface
+{
+    /**
+     * @var ProcessorInterface
+     */
+    private $processor;
+
+    /**
+     * @var string
+     */
+    private $queueName;
+
+    /**
+     * @var callable
+     */
+    private $callback;
+
+    /**
+     * @var LoggerInterface
+     */
+    private $logger;
+
+    /**
+     * @param ProcessorInterface   $processor
+     * @param string               $queueName
+     * @param callable             $callback
+     * @param LoggerInterface|null $logger
+     */
+    public function __construct(
+        ProcessorInterface $processor,
+        string $queueName,
+        callable $callback,
+        LoggerInterface $logger = null
+    ) {
+        $this->processor = $processor;
+        $this->queueName = $queueName;
+        $this->callback = $callback;
+        $this->logger = $logger ?: new NullLogger();
+    }
+
+    /**
+     * {@inheritdoc}
+     */
+    public function setDefaultOptions(OptionsResolver $resolver)
+    {
+        $resolver
+            ->setDefaults(array(
+                'x_death_max_count' => 300,
+                'x_death_max_count_log_levels_map' => array(),
+                'x_death_max_count_fail_log_levels_map' => array(),
+            ))
+            ->setAllowedTypes('x_death_max_count', 'int')
+            ->setAllowedTypes('x_death_max_count_log_levels_map', 'array')
+            ->setAllowedTypes('x_death_max_count_fail_log_levels_map', 'array');
+    }
+
+    /**
+     * {@inheritdoc}
+     */
+    public function process(Message $message, array $options)
+    {
+        try {
+            return $this->processor->process($message, $options);
+        } catch (\Throwable $e) {
+            return $this->handleException($e, $message, $options);
+        } catch (\Exception $e) {
+            return $this->handleException($e, $message, $options);
+        }
+    }
+
+    /**
+     * @param \Exception|\Throwable $exception
+     * @param Message               $message
+     * @param array                 $options
+     *
+     * @return mixed
+     */
+    private function handleException($exception, Message $message, array $options)
+    {
+        $headers = $message->getProperties();
+        if (isset($headers['headers']['x-death'])) {
+            $xDeathHeaders = $headers['headers']['x-death'];
+            // PhpAmqpLib compatibility
+            if ($xDeathHeaders instanceof AMQPArray) {
+                $xDeathHeaders = $headers['headers']['x-death']->getNativeData();
+            }
+
+            $queueXDeathHeader = null;
+            foreach ($xDeathHeaders as $xDeathHeader) {
+                if (isset($xDeathHeader['queue']) && $xDeathHeader['queue'] === $this->queueName) {
+                    $queueXDeathHeader = $xDeathHeader;
+                    break;
+                }
+            }
+
+            if (null === $queueXDeathHeader) {
+                $this->logException(
+                    $exception,
+                    sprintf(
+                        '[XDeathMaxCount] No x-death header found for queue name "%s". Do nothing.',
+                        $this->queueName
+                    ),
+                    $options['x_death_max_count_fail_log_levels_map']
+                );
+            } elseif (isset($queueXDeathHeader['count'])) {
+                if ($queueXDeathHeader['count'] >= $options['x_death_max_count']) {
+                    $this->logException(
+                        $exception,
+                        sprintf(
+                            '[XDeathMaxCount] Max count reached. %d/%d attempts. Execute the configured callback.',
+                            $queueXDeathHeader['count'],
+                            $options['x_death_max_count']
+                        ),
+                        $options['x_death_max_count_fail_log_levels_map']
+                    );
+
+                    if (null !== $return = \call_user_func($this->callback, $exception, $message, $options)) {
+                        return $return;
+                    }
+                } else {
+                    $this->logException(
+                        $exception,
+                        sprintf(
+                            '[XDeathMaxCount] %d/%d attempts.',
+                            $queueXDeathHeader['count'],
+                            $options['x_death_max_count']
+                        ),
+                        $options['x_death_max_count_log_levels_map']
+                    );
+                }
+            }
+        }
+
+        throw $exception;
+    }
+
+    /**
+     * @param \Exception|\Throwable $exception
+     * @param string                $logMessage
+     * @param array                 $logLevelsMap
+     */
+    private function logException($exception, $logMessage, array $logLevelsMap)
+    {
+        $logLevel = LogLevel::WARNING;
+
+        foreach ($logLevelsMap as $className => $level) {
+            if ($exception instanceof $className) {
+                $logLevel = $level;
+
+                break;
+            }
+        }
+
+        $this->logger->log(
+            $logLevel,
+            $logMessage,
+            [
+                'swarrot_processor' => 'x_death_max_count',
+                'exception' => $exception,
+            ]
+        );
+    }
+}

--- a/src/Swarrot/Processor/XDeath/XDeathMaxLifetimeProcessor.php
+++ b/src/Swarrot/Processor/XDeath/XDeathMaxLifetimeProcessor.php
@@ -1,0 +1,182 @@
+<?php
+
+namespace Swarrot\Processor\XDeath;
+
+use PhpAmqpLib\Wire\AMQPArray;
+use Psr\Log\LoggerInterface;
+use Psr\Log\LogLevel;
+use Psr\Log\NullLogger;
+use Swarrot\Broker\Message;
+use Swarrot\Processor\ProcessorInterface;
+use Swarrot\Processor\ConfigurableInterface;
+use Symfony\Component\OptionsResolver\OptionsResolver;
+
+class XDeathMaxLifetimeProcessor implements ConfigurableInterface
+{
+    /**
+     * @var ProcessorInterface
+     */
+    private $processor;
+
+    /**
+     * @var string
+     */
+    private $queueName;
+
+    /**
+     * @var callable
+     */
+    private $callback;
+
+    /**
+     * @var LoggerInterface
+     */
+    private $logger;
+
+    /**
+     * @param ProcessorInterface   $processor
+     * @param string               $queueName
+     * @param callable             $callback
+     * @param LoggerInterface|null $logger
+     */
+    public function __construct(
+        ProcessorInterface $processor,
+        string $queueName,
+        callable $callback,
+        LoggerInterface $logger = null
+    ) {
+        $this->processor = $processor;
+        $this->queueName = $queueName;
+        $this->callback = $callback;
+        $this->logger = $logger ?: new NullLogger();
+    }
+
+    /**
+     * {@inheritdoc}
+     */
+    public function setDefaultOptions(OptionsResolver $resolver)
+    {
+        $resolver
+            ->setDefaults(array(
+                'x_death_max_lifetime' => 3600,
+                'x_death_max_lifetime_log_levels_map' => array(),
+                'x_death_max_lifetime_fail_log_levels_map' => array(),
+            ))
+            ->setAllowedTypes('x_death_max_lifetime', 'int')
+            ->setAllowedTypes('x_death_max_lifetime_log_levels_map', 'array')
+            ->setAllowedTypes('x_death_max_lifetime_fail_log_levels_map', 'array');
+    }
+
+    /**
+     * {@inheritdoc}
+     */
+    public function process(Message $message, array $options)
+    {
+        try {
+            return $this->processor->process($message, $options);
+        } catch (\Throwable $e) {
+            return $this->handleException($e, $message, $options);
+        } catch (\Exception $e) {
+            return $this->handleException($e, $message, $options);
+        }
+    }
+
+    /**
+     * @param \Exception|\Throwable $exception
+     * @param Message               $message
+     * @param array                 $options
+     *
+     * @return mixed
+     */
+    private function handleException($exception, Message $message, array $options)
+    {
+        $headers = $message->getProperties();
+        if (isset($headers['headers']['x-death'])) {
+            $xDeathHeaders = $headers['headers']['x-death'];
+            // PhpAmqpLib compatibility
+            if ($xDeathHeaders instanceof AMQPArray) {
+                $xDeathHeaders = $headers['headers']['x-death']->getNativeData();
+            }
+
+            $queueXDeathHeader = null;
+            foreach ($xDeathHeaders as $xDeathHeader) {
+                if (isset($xDeathHeader['queue']) && $xDeathHeader['queue'] === $this->queueName) {
+                    $queueXDeathHeader = $xDeathHeader;
+                    break;
+                }
+            }
+
+            if (null === $queueXDeathHeader) {
+                $this->logException(
+                    $exception,
+                    sprintf(
+                        '[XDeathMaxLifetime] No x-death header found for queue name "%s". Do nothing.',
+                        $this->queueName
+                    ),
+                    $options['x_death_max_lifetime_fail_log_levels_map']
+                );
+            } elseif (isset($queueXDeathHeader['time'])) {
+                $xDeathTimestamp = $queueXDeathHeader['time'];
+                // PhpAmqpLib compatibility
+                if ($xDeathTimestamp instanceof \DateTime) {
+                    $xDeathTimestamp = $xDeathTimestamp->getTimestamp();
+                }
+                $remainLifetime = $xDeathTimestamp - (time() - $options['x_death_max_lifetime']);
+                if ($remainLifetime <= 0) {
+                    $this->logException(
+                        $exception,
+                        sprintf(
+                            '[XDeathMaxLifetime] Max lifetime reached. %s/%s seconds exceed. Execute the configured callback.',
+                            abs($remainLifetime),
+                            $options['x_death_max_lifetime']
+                        ),
+                        $options['x_death_max_lifetime_fail_log_levels_map']
+                    );
+
+                    if (null !== $return = \call_user_func($this->callback, $exception, $message, $options)) {
+                        return $return;
+                    }
+                } else {
+                    $this->logException(
+                        $exception,
+                        sprintf(
+                            '[XDeathMaxLifetime] Lifetime remain %d/%d seconds.',
+                            $remainLifetime,
+                            $options['x_death_max_lifetime']
+                        ),
+                        $options['x_death_max_lifetime_log_levels_map']
+                    );
+                }
+            }
+        }
+
+        throw $exception;
+    }
+
+    /**
+     * @param \Exception|\Throwable $exception
+     * @param string                $logMessage
+     * @param array                 $logLevelsMap
+     */
+    private function logException($exception, $logMessage, array $logLevelsMap)
+    {
+        $logLevel = LogLevel::WARNING;
+
+        foreach ($logLevelsMap as $className => $level) {
+            if ($exception instanceof $className) {
+                $logLevel = $level;
+
+                break;
+            }
+        }
+
+        $this->logger->log(
+            $logLevel,
+            $logMessage,
+            [
+                'swarrot_processor' => 'x_death_max_lifetime',
+                'exception' => $exception,
+            ]
+        );
+    }
+}

--- a/tests/Swarrot/Processor/XDeath/XDeathMaxCountProcessorTest.php
+++ b/tests/Swarrot/Processor/XDeath/XDeathMaxCountProcessorTest.php
@@ -1,0 +1,351 @@
+<?php
+
+namespace Swarrot\Tests\Processor\XDeath;
+
+use PhpAmqpLib\Wire\AMQPArray;
+use PhpAmqpLib\Wire\AMQPTable;
+use PHPUnit\Framework\TestCase;
+use Prophecy\Argument;
+use Psr\Log\LoggerInterface;
+use Psr\Log\LogLevel;
+use Swarrot\Broker\Message;
+use Swarrot\Processor\ProcessorInterface;
+use Swarrot\Processor\XDeath\XDeathMaxCountProcessor;
+use Symfony\Component\OptionsResolver\OptionsResolver;
+
+class XDeathMaxCountProcessorTest extends TestCase
+{
+    public function test_it_is_initializable_without_a_logger()
+    {
+        $processorMock = $this->prophesize(ProcessorInterface::class);
+        $callback = function () {
+        };
+
+        $processor = new XDeathMaxCountProcessor($processorMock->reveal(), 'good_queue', $callback);
+        $this->assertInstanceOf(XDeathMaxCountProcessor::class, $processor);
+    }
+
+    public function test_it_is_initializable_with_a_logger()
+    {
+        $processorMock = $this->prophesize(ProcessorInterface::class);
+
+        $callback = function () {
+        };
+
+        $logger = $this->prophesize(LoggerInterface::class);
+
+        $processor = new XDeathMaxCountProcessor($processorMock->reveal(), 'good_queue', $callback, $logger->reveal());
+        $this->assertInstanceOf(XDeathMaxCountProcessor::class, $processor);
+    }
+
+    public function test_it_should_return_result_when_all_is_right()
+    {
+        $message = new Message('body', array(), 1);
+
+        $processorMock = $this->prophesize(ProcessorInterface::class);
+        $processorMock->process(Argument::exact($message), Argument::exact(array()))->willReturn(null);
+
+        $callback = function () {
+        };
+
+        $logger = $this->prophesize(LoggerInterface::class);
+
+        $processor = new XDeathMaxCountProcessor($processorMock->reveal(), 'good_queue', $callback, $logger->reveal());
+        $this->assertNull($processor->process($message, array()));
+    }
+
+    public function test_it_should_rethrow_when_an_exception_occurred()
+    {
+        $this->expectException('\BadMethodCallException');
+
+        $message = new Message('body', array(), 1);
+
+        $options = [];
+        $processorMock = $this->prophesize(ProcessorInterface::class);
+        $processorMock
+            ->process(
+                Argument::exact($message),
+                Argument::exact($options)
+            )->willThrow('\BadMethodCallException')
+            ->shouldBeCalledTimes(1);
+
+        $callback = function () {
+        };
+
+        $logger = $this->prophesize(LoggerInterface::class);
+
+        $processor = new XDeathMaxCountProcessor($processorMock->reveal(), 'good_queue', $callback, $logger->reveal());
+        $processor->process($message, $options);
+    }
+
+    public function test_it_should_return_a_valid_array_of_option()
+    {
+        $processorMock = $this->prophesize(ProcessorInterface::class);
+
+        $callback = function () {
+        };
+
+        $optionsResolver = new OptionsResolver();
+        $logger = $this->prophesize(LoggerInterface::class);
+
+        $processor = new XDeathMaxCountProcessor($processorMock->reveal(), 'good_queue', $callback, $logger->reveal());
+        $processor->setDefaultOptions($optionsResolver);
+
+        $config = $optionsResolver->resolve(array());
+
+        $this->assertEquals(array(
+            'x_death_max_count' => 300,
+            'x_death_max_count_log_levels_map' => array(),
+            'x_death_max_count_fail_log_levels_map' => array(),
+        ), $config);
+    }
+
+    public function messageProvider()
+    {
+        $data = [
+            [
+                new Message(
+                    null,
+                    [
+                        'headers' => [
+                            'x-death' => [
+                                ['count' => 1],
+                                ['queue' => 'other_queue', 'count' => 2],
+                                ['queue' => 'good_queue', 'count' => 4],
+                            ],
+                        ],
+                    ]
+                ),
+            ],
+        ];
+        if (class_exists('PhpAmqpLib\Wire\AMQPArray') && class_exists('PhpAmqpLib\Wire\AMQPTable')) {
+            $data[] = [
+                new Message(
+                    null,
+                    [
+                        'headers' => [
+                            'x-death' => new AMQPArray([
+                                new AMQPTable([
+                                    'count' => '1',
+                                ]),
+                                new AMQPTable([
+                                    'queue' => 'other_queue',
+                                    'count' => '2',
+                                ]),
+                                new AMQPTable([
+                                    'queue' => 'good_queue',
+                                    'count' => '4',
+                                ]),
+                            ]),
+                        ],
+                    ]
+                ),
+            ];
+        }
+
+        return $data;
+    }
+
+    /**
+     * @dataProvider messageProvider
+     *
+     * @param $message
+     */
+    public function test_it_should_not_rethrow_with_x_death_max_count_reached($message)
+    {
+        $options = array(
+            'x_death_max_count' => 1,
+            'x_death_max_count_log_levels_map' => array(),
+            'x_death_max_count_fail_log_levels_map' => array(),
+        );
+
+        $processorMock = $this->prophesize(ProcessorInterface::class);
+        $processorMock
+            ->process(Argument::exact($message), Argument::exact($options))
+            ->willThrow('\BadMethodCallException')
+            ->shouldBeCalled();
+
+        $callback = function () {
+            return 'my_fake_return';
+        };
+
+        $logger = $this->prophesize(LoggerInterface::class);
+        $logger
+            ->log('warning', '[XDeathMaxCount] Max count reached. 4/1 attempts. Execute the configured callback.', Argument::cetera())
+            ->shouldBeCalled();
+
+        $processor = new XDeathMaxCountProcessor($processorMock->reveal(), 'good_queue', $callback, $logger->reveal());
+        $this->assertEquals('my_fake_return', $processor->process($message, $options));
+    }
+
+    /**
+     * @dataProvider messageProvider
+     *
+     * @param $message
+     */
+    public function test_it_should_rethrow_with_x_death_max_count_reached($message)
+    {
+        $this->expectException('\BadMethodCallException');
+
+        $options = array(
+            'x_death_max_count' => 1,
+            'x_death_max_count_log_levels_map' => array(),
+            'x_death_max_count_fail_log_levels_map' => array(),
+        );
+
+        $processorMock = $this->prophesize(ProcessorInterface::class);
+        $processorMock
+            ->process(Argument::exact($message), Argument::exact($options))
+            ->willThrow('\BadMethodCallException')
+            ->shouldBeCalledTimes(1);
+
+        $callback = function () {
+            return;
+        };
+
+        $logger = $this->prophesize(LoggerInterface::class);
+        $logger
+            ->log('warning', '[XDeathMaxCount] Max count reached. 4/1 attempts. Execute the configured callback.', Argument::cetera())
+            ->shouldBeCalled();
+
+        $processor = new XDeathMaxCountProcessor($processorMock->reveal(), 'good_queue', $callback, $logger->reveal());
+        $processor->process($message, $options);
+    }
+
+    /**
+     * @dataProvider messageProvider
+     *
+     * @param $message
+     */
+    public function test_it_should_rethrow_with_x_death_max_count_not_reached($message)
+    {
+        $this->expectException('\BadMethodCallException');
+
+        $options = array(
+            'x_death_max_count' => 10,
+            'x_death_max_count_log_levels_map' => array(),
+            'x_death_max_count_fail_log_levels_map' => array(),
+        );
+
+        $processorMock = $this->prophesize(ProcessorInterface::class);
+        $processorMock
+            ->process(Argument::exact($message), Argument::exact($options))
+            ->willThrow('\BadMethodCallException')
+            ->shouldBeCalledTimes(1);
+
+        $callback = function () {
+            return 'my_fake_return';
+        };
+
+        $logger = $this->prophesize(LoggerInterface::class);
+        $logger
+            ->log('warning', '[XDeathMaxCount] 4/10 attempts.', Argument::cetera())
+            ->shouldBeCalled();
+
+        $processor = new XDeathMaxCountProcessor($processorMock->reveal(), 'good_queue', $callback, $logger->reveal());
+        $processor->process($message, $options);
+    }
+
+    /**
+     * @dataProvider messageProvider
+     *
+     * @param $message
+     */
+    public function test_it_should_log_a_custom_log_level_with_x_death_max_count_reached($message)
+    {
+        $options = array(
+            'x_death_max_count' => 1,
+            'x_death_max_count_log_levels_map' => array(),
+            'x_death_max_count_fail_log_levels_map' => array(
+                '\BadMethodCallException' => LogLevel::CRITICAL,
+            ),
+        );
+
+        $processorMock = $this->prophesize(ProcessorInterface::class);
+        $processorMock
+            ->process(Argument::exact($message), Argument::exact($options))
+            ->willThrow('\BadMethodCallException')
+            ->shouldBeCalledTimes(1);
+
+        $callback = function () {
+            return 'my_fake_return';
+        };
+
+        $logger = $this->prophesize(LoggerInterface::class);
+        $logger
+            ->log('critical', '[XDeathMaxCount] Max count reached. 4/1 attempts. Execute the configured callback.', Argument::cetera())
+            ->shouldBeCalled();
+
+        $processor = new XDeathMaxCountProcessor($processorMock->reveal(), 'good_queue', $callback, $logger->reveal());
+        $this->assertEquals('my_fake_return', $processor->process($message, $options));
+    }
+
+    /**
+     * @dataProvider messageProvider
+     *
+     * @param $message
+     */
+    public function test_it_should_log_a_custom_log_level_with_x_death_max_count_not_reached($message)
+    {
+        $this->expectException('\BadMethodCallException');
+
+        $options = array(
+            'x_death_max_count' => 10,
+            'x_death_max_count_log_levels_map' => array(
+                '\BadMethodCallException' => LogLevel::CRITICAL,
+            ),
+            'x_death_max_count_fail_log_levels_map' => array(),
+        );
+
+        $processorMock = $this->prophesize(ProcessorInterface::class);
+        $processorMock
+            ->process(Argument::exact($message), Argument::exact($options))
+            ->willThrow('\BadMethodCallException')
+            ->shouldBeCalledTimes(1);
+
+        $callback = function () {
+            return 'my_fake_return';
+        };
+
+        $logger = $this->prophesize(LoggerInterface::class);
+        $logger
+            ->log('critical', '[XDeathMaxCount] 4/10 attempts.', Argument::cetera())
+            ->shouldBeCalled();
+
+        $processor = new XDeathMaxCountProcessor($processorMock->reveal(), 'good_queue', $callback, $logger->reveal());
+        $processor->process($message, $options);
+    }
+
+    /**
+     * @dataProvider messageProvider
+     *
+     * @param $message
+     */
+    public function test_it_should_log_x_death_max_count_not_found($message)
+    {
+        $this->expectException('\BadMethodCallException');
+
+        $options = array(
+            'x_death_max_count' => 10,
+            'x_death_max_count_log_levels_map' => array(),
+            'x_death_max_count_fail_log_levels_map' => array(),
+        );
+        $processorMock = $this->prophesize(ProcessorInterface::class);
+        $processorMock
+            ->process(Argument::exact($message), Argument::exact($options))
+            ->willThrow('\BadMethodCallException')
+            ->shouldBeCalledTimes(1);
+
+        $callback = function () {
+            return 'my_fake_return';
+        };
+
+        $logger = $this->prophesize(LoggerInterface::class);
+        $logger
+            ->log('warning', '[XDeathMaxCount] No x-death header found for queue name "not_found_queue". Do nothing.', Argument::cetera())
+            ->shouldBeCalled();
+
+        $processor = new XDeathMaxCountProcessor($processorMock->reveal(), 'not_found_queue', $callback, $logger->reveal());
+        $processor->process($message, $options);
+    }
+}

--- a/tests/Swarrot/Processor/XDeath/XDeathMaxLifetimeProcessorTest.php
+++ b/tests/Swarrot/Processor/XDeath/XDeathMaxLifetimeProcessorTest.php
@@ -1,0 +1,385 @@
+<?php
+
+namespace Swarrot\Tests\Processor\XDeath;
+
+use PhpAmqpLib\Wire\AMQPArray;
+use PhpAmqpLib\Wire\AMQPTable;
+use PHPUnit\Framework\TestCase;
+use Prophecy\Argument;
+use Psr\Log\LoggerInterface;
+use Psr\Log\LogLevel;
+use Swarrot\Broker\Message;
+use Swarrot\Processor\ProcessorInterface;
+use Swarrot\Processor\XDeath\XDeathMaxLifetimeProcessor;
+use Symfony\Component\OptionsResolver\OptionsResolver;
+
+class XDeathMaxLifetimeProcessorTest extends TestCase
+{
+    public function test_it_is_initializable_without_a_logger()
+    {
+        $processorMock = $this->prophesize(ProcessorInterface::class);
+
+        $callback = function () {
+        };
+
+        $processor = new XDeathMaxLifetimeProcessor($processorMock->reveal(), 'good_queue', $callback);
+        $this->assertInstanceOf(XDeathMaxLifetimeProcessor::class, $processor);
+    }
+
+    public function test_it_is_initializable_with_a_logger()
+    {
+        $processorMock = $this->prophesize(ProcessorInterface::class);
+
+        $callback = function () {
+        };
+
+        $logger = $this->prophesize(LoggerInterface::class);
+
+        $processor = new XDeathMaxLifetimeProcessor($processorMock->reveal(), 'good_queue', $callback, $logger->reveal());
+        $this->assertInstanceOf(XDeathMaxLifetimeProcessor::class, $processor);
+    }
+
+    public function test_it_should_return_result_when_all_is_right()
+    {
+        $message = new Message('body', array(), 1);
+
+        $processorMock = $this->prophesize(ProcessorInterface::class);
+        $processorMock->process(Argument::exact($message), Argument::exact(array()))->willReturn(null);
+
+        $callback = function () {
+        };
+
+        $logger = $this->prophesize(LoggerInterface::class);
+
+        $processor = new XDeathMaxLifetimeProcessor($processorMock->reveal(), 'good_queue', $callback, $logger->reveal());
+        $this->assertNull($processor->process($message, array()));
+    }
+
+    public function test_it_should_rethrow_when_an_exception_occurred()
+    {
+        $this->expectException('\BadMethodCallException');
+
+        $message = new Message('body', array(), 1);
+
+        $options = [];
+
+        $processorMock = $this->prophesize(ProcessorInterface::class);
+        $processorMock
+            ->process(
+                Argument::exact($message),
+                Argument::exact($options)
+            )->willThrow('\BadMethodCallException')
+            ->shouldBeCalledTimes(1);
+
+        $callback = function () {
+        };
+
+        $logger = $this->prophesize(LoggerInterface::class);
+
+        $processor = new XDeathMaxLifetimeProcessor($processorMock->reveal(), 'good_queue', $callback, $logger->reveal());
+        $this->assertNull($processor->process($message, $options));
+    }
+
+    public function test_it_should_return_a_valid_array_of_option()
+    {
+        $processorMock = $this->prophesize(ProcessorInterface::class);
+
+        $callback = function () {
+        };
+
+        $optionsResolver = new OptionsResolver();
+        $logger = $this->prophesize(LoggerInterface::class);
+
+        $processor = new XDeathMaxLifetimeProcessor($processorMock->reveal(), 'good_queue', $callback, $logger->reveal());
+        $processor->setDefaultOptions($optionsResolver);
+
+        $config = $optionsResolver->resolve(array());
+
+        $this->assertEquals(array(
+            'x_death_max_lifetime' => 3600,
+            'x_death_max_lifetime_log_levels_map' => array(),
+            'x_death_max_lifetime_fail_log_levels_map' => array(),
+        ), $config);
+    }
+
+    public function messageProvider()
+    {
+        $data = [
+            [
+                new Message(
+                    null,
+                    [
+                        'headers' => [
+                            'x-death' => [
+                                ['count' => 1],
+                                ['queue' => 'other_queue', 'count' => 2],
+                                ['queue' => 'good_queue', 'time' => time() - 5],
+                            ],
+                        ],
+                    ]
+                ),
+            ],
+        ];
+
+        if (class_exists('PhpAmqpLib\Wire\AMQPArray') && class_exists('PhpAmqpLib\Wire\AMQPTable')) {
+            $data[] = [
+                new Message(
+                    null,
+                    [
+                        'headers' => [
+                            'x-death' => new AMQPArray([
+                                new AMQPTable([
+                                    'time' => new \DateTime('10 seconds'),
+                                ]),
+                                new AMQPTable([
+                                    'queue' => 'other_queue',
+                                    'time' => new \DateTime('15 seconds'),
+                                ]),
+                                new AMQPTable([
+                                    'queue' => 'good_queue',
+                                    'time' => new \DateTime('-5 seconds'),
+                                ]),
+                            ]),
+                        ],
+                    ]
+                ),
+            ];
+        }
+
+        return $data;
+    }
+
+    /**
+     * @dataProvider messageProvider
+     *
+     * @param $message
+     */
+    public function test_it_should_not_rethrow_with_x_death_max_lifetime_reached($message)
+    {
+        $options = array(
+            'x_death_max_lifetime' => 1,
+            'x_death_max_lifetime_log_levels_map' => array(),
+            'x_death_max_lifetime_fail_log_levels_map' => array(),
+        );
+
+        $processorMock = $this->prophesize(ProcessorInterface::class);
+        $processorMock
+            ->process(Argument::exact($message), Argument::exact($options))
+            ->willThrow('\BadMethodCallException')
+            ->shouldBeCalledTimes(1);
+
+        $callback = function () {
+            return 'my_fake_return';
+        };
+
+        $logger = $this->prophesize(LoggerInterface::class);
+        $logger
+            ->log(
+                'warning',
+                Argument::that(function ($value) {
+                    return preg_match('/\[XDeathMaxLifetime\] Max lifetime reached. \d+\/1 seconds exceed. Execute the configured callback\./', $value);
+                }),
+                Argument::cetera()
+            )
+            ->shouldBeCalled();
+
+        $processor = new XDeathMaxLifetimeProcessor($processorMock->reveal(), 'good_queue', $callback, $logger->reveal());
+        $this->assertEquals('my_fake_return', $processor->process($message, $options));
+    }
+
+    /**
+     * @dataProvider messageProvider
+     *
+     * @param $message
+     */
+    public function test_it_should_rethrow_with_x_death_max_lifetime_reached($message)
+    {
+        $this->expectException('\BadMethodCallException');
+
+        $options = array(
+            'x_death_max_lifetime' => 1,
+            'x_death_max_lifetime_log_levels_map' => array(),
+            'x_death_max_lifetime_fail_log_levels_map' => array(),
+        );
+
+        $processorMock = $this->prophesize(ProcessorInterface::class);
+        $processorMock
+            ->process(Argument::exact($message), Argument::exact($options))
+            ->willThrow('\BadMethodCallException')
+            ->shouldBeCalledTimes(1);
+
+        $callback = function () {
+            return;
+        };
+
+        $logger = $this->prophesize(LoggerInterface::class);
+        $logger
+            ->log(
+                'warning',
+                Argument::that(function ($value) {
+                    return preg_match('/\[XDeathMaxLifetime\] Max lifetime reached. \d+\/1 seconds exceed. Execute the configured callback\./', $value);
+                }),
+                Argument::cetera()
+            )
+            ->shouldBeCalled();
+
+        $processor = new XDeathMaxLifetimeProcessor($processorMock->reveal(), 'good_queue', $callback, $logger->reveal());
+        $processor->process($message, $options);
+    }
+
+    /**
+     * @dataProvider messageProvider
+     *
+     * @param $message
+     */
+    public function test_it_should_rethrow_with_x_death_max_lifetime_not_reached($message)
+    {
+        $this->expectException('\BadMethodCallException');
+
+        $options = array(
+            'x_death_max_lifetime' => 10,
+            'x_death_max_lifetime_log_levels_map' => array(),
+            'x_death_max_lifetime_fail_log_levels_map' => array(),
+        );
+
+        $processorMock = $this->prophesize(ProcessorInterface::class);
+        $processorMock
+            ->process(Argument::exact($message), Argument::exact($options))
+            ->willThrow('\BadMethodCallException')
+            ->shouldBeCalledTimes(1);
+
+        $callback = function () {
+            return;
+        };
+
+        $logger = $this->prophesize(LoggerInterface::class);
+        $logger
+            ->log(
+                'warning',
+                Argument::that(function ($value) {
+                    return preg_match('/\[XDeathMaxLifetime\] Lifetime remain \d+\/10 seconds\./', $value);
+                }),
+                Argument::cetera()
+            )
+            ->shouldBeCalled();
+
+        $processor = new XDeathMaxLifetimeProcessor($processorMock->reveal(), 'good_queue', $callback, $logger->reveal());
+        $processor->process($message, $options);
+    }
+
+    /**
+     * @dataProvider messageProvider
+     *
+     * @param $message
+     */
+    public function test_it_should_log_a_custom_log_level_with_x_death_max_lifetime_reached($message)
+    {
+        $options = array(
+            'x_death_max_lifetime' => 1,
+            'x_death_max_lifetime_log_levels_map' => array(),
+            'x_death_max_lifetime_fail_log_levels_map' => array(
+                '\BadMethodCallException' => LogLevel::CRITICAL,
+            ),
+        );
+
+        $processorMock = $this->prophesize(ProcessorInterface::class);
+        $processorMock
+            ->process(Argument::exact($message), Argument::exact($options))
+            ->willThrow('\BadMethodCallException')
+            ->shouldBeCalledTimes(1);
+
+        $callback = function () {
+            return 'my_fake_return';
+        };
+
+        $logger = $this->prophesize(LoggerInterface::class);
+        $logger
+            ->log(
+                'critical',
+                Argument::that(function ($value) {
+                    return preg_match('/\[XDeathMaxLifetime\] Max lifetime reached. \d+\/1 seconds exceed. Execute the configured callback\./', $value);
+                }),
+                Argument::cetera()
+            )
+            ->shouldBeCalled();
+
+        $processor = new XDeathMaxLifetimeProcessor($processorMock->reveal(), 'good_queue', $callback, $logger->reveal());
+        $this->assertEquals('my_fake_return', $processor->process($message, $options));
+    }
+
+    /**
+     * @dataProvider messageProvider
+     *
+     * @param $message
+     */
+    public function test_it_should_log_a_custom_log_level_with_x_death_max_lifetime_not_reached($message)
+    {
+        $this->expectException('\BadMethodCallException');
+
+        $options = array(
+            'x_death_max_lifetime' => 10,
+            'x_death_max_lifetime_log_levels_map' => array(
+                '\BadMethodCallException' => LogLevel::CRITICAL,
+            ),
+            'x_death_max_lifetime_fail_log_levels_map' => array(),
+        );
+
+        $processorMock = $this->prophesize(ProcessorInterface::class);
+        $processorMock
+            ->process(Argument::exact($message), Argument::exact($options))
+            ->willThrow('\BadMethodCallException')
+            ->shouldBeCalledTimes(1);
+
+        $callback = function () {
+            return;
+        };
+
+        $logger = $this->prophesize(LoggerInterface::class);
+        $logger
+            ->log(
+                'critical',
+                Argument::that(function ($value) {
+                    return preg_match('/\[XDeathMaxLifetime\] Lifetime remain \d+\/10 seconds\./', $value);
+                }),
+                Argument::cetera()
+            )
+            ->shouldBeCalled();
+
+        $processor = new XDeathMaxLifetimeProcessor($processorMock->reveal(), 'good_queue', $callback, $logger->reveal());
+        $processor->process($message, $options);
+    }
+
+    /**
+     * @dataProvider messageProvider
+     *
+     * @param $message
+     */
+    public function test_it_should_log_x_death_max_lifetime_not_found($message)
+    {
+        $this->expectException('\BadMethodCallException');
+
+        $options = array(
+            'x_death_max_lifetime' => 10,
+            'x_death_max_lifetime_log_levels_map' => array(),
+            'x_death_max_lifetime_fail_log_levels_map' => array(),
+        );
+
+        $processorMock = $this->prophesize(ProcessorInterface::class);
+        $processorMock
+            ->process(Argument::exact($message), Argument::exact($options))
+            ->willThrow('\BadMethodCallException')
+            ->shouldBeCalledTimes(1);
+
+        $callback = function () {
+            return;
+        };
+
+        $logger = $this->prophesize(LoggerInterface::class);
+        $logger
+            ->log('warning', '[XDeathMaxLifetime] No x-death header found for queue name "not_found_queue". Do nothing.', Argument::cetera())
+            ->shouldBeCalled();
+
+        $processor = new XDeathMaxLifetimeProcessor($processorMock->reveal(), 'not_found_queue', $callback, $logger->reveal());
+        $processor->process($message, $options);
+    }
+}


### PR DESCRIPTION
|**Q**|**A**|
| ------------- |:-------------:|
| Branch? | master|
| Bug fix? | no |
| New feature? | yes |
| BC breaks? | no |
| Deprecations? | no |
| Tests pass? | yes |

Hi

When we use rabbitMQ retry (DLX, DLK) with nack message we need to correctly handle poison message. 
So there is 2 new middlewares.
 - XDeathMaxCountProcessor
 - XDeathMaxLifetimeProcessor

hope you enjoy :)