### PR TITLE
Enhance CallbackProcessor and CallbackMessageProvider

### DIFF
--- a/examples/02-consumer-and-provider-using-callable.php
+++ b/examples/02-consumer-and-provider-using-callable.php
@@ -1,0 +1,56 @@
+<?php
+
+require_once __DIR__.'/../vendor/autoload.php';
+
+use Swarrot\Consumer;
+use Swarrot\Broker\Message;
+use Swarrot\Broker\MessageProvider\CallbackMessageProvider;
+use Swarrot\Processor\Callback\CallbackProcessor;
+
+class WeatherIntervalMessageProvider
+{
+    private $date;
+    private $interval;
+
+    public function __construct(DateInterval $interval)
+    {
+        $this->interval = $interval;
+    }
+
+    public function __invoke()
+    {
+        if (null === $this->date || (new DateTime())->sub($this->interval) > $this->date) {
+            $this->date = new DateTime();
+
+            return new Message(
+                file_get_contents('https://query.yahooapis.com/v1/public/yql?q=select%20item.condition%20from%20weather.forecast%20where%20woeid%20%3D%20615702&format=json&env=store%3A%2F%2Fdatatables.org%2Falltableswithkeys')
+            );
+        }
+
+        return null;
+    }
+}
+
+class WeatherMessageProcessor
+{
+    public function process(Message $message, array $options)
+    {
+        $weather = json_decode($message->getBody(), true);
+        if (empty($weather['query']['results']['channel']['item']['condition']['text'])) {
+            echo 'Invalid Input';
+
+            return;
+        }
+
+        printf("The weather is %s in Paris\n", $weather['query']['results']['channel']['item']['condition']['text']);
+    }
+}
+
+$intervalMessageProvider = new WeatherIntervalMessageProvider(new DateInterval('PT5S'));
+$weatherMessageProcessor = new WeatherMessageProcessor();
+$messageProvider = new CallbackMessageProvider($intervalMessageProvider);
+$processor = new CallbackProcessor([$weatherMessageProcessor, 'process']);
+
+$consumer = new Consumer($messageProvider, $processor);
+
+$consumer->consume([]);

--- a/src/Swarrot/Broker/MessageProvider/CallbackMessageProvider.php
+++ b/src/Swarrot/Broker/MessageProvider/CallbackMessageProvider.php
@@ -6,22 +6,27 @@ use Swarrot\Broker\Message;
 
 class CallbackMessageProvider implements MessageProviderInterface
 {
-    /*
-     * @var Closure
+    /**
+     * @var callable
      */
     protected $get;
 
-    /*
-     * @var Closure
+    /**
+     * @var callable
      */
     protected $ack;
 
-    /*
-     * @var Closure
+    /**
+     * @var callable
      */
     protected $nack;
 
-    public function __construct(\Closure $get, \Closure $ack = null, \Closure $nack = null)
+    /**
+     * @param callable      $get
+     * @param callable|null $ack
+     * @param callable|null $nack
+     */
+    public function __construct(callable $get, callable $ack = null, callable $nack = null)
     {
         $this->get = $get;
         $this->ack = $ack;
@@ -45,7 +50,7 @@ class CallbackMessageProvider implements MessageProviderInterface
             return;
         }
 
-        return call_user_func($this->ack, $message);
+        call_user_func($this->ack, $message);
     }
 
     /**
@@ -57,7 +62,7 @@ class CallbackMessageProvider implements MessageProviderInterface
             return;
         }
 
-        return call_user_func($this->nack, $message, $requeue);
+        call_user_func($this->nack, $message, $requeue);
     }
 
     /**

--- a/src/Swarrot/Processor/Callback/CallbackProcessor.php
+++ b/src/Swarrot/Processor/Callback/CallbackProcessor.php
@@ -7,9 +7,15 @@ use Swarrot\Processor\ProcessorInterface;
 
 class CallbackProcessor implements ProcessorInterface
 {
+    /**
+     * @var callable
+     */
     protected $process;
 
-    public function __construct(\Closure $process)
+    /**
+     * @param callable $process
+     */
+    public function __construct(callable $process)
     {
         $this->process = $process;
     }
@@ -19,6 +25,6 @@ class CallbackProcessor implements ProcessorInterface
      */
     public function process(Message $message, array $options)
     {
-        call_user_func($this->process, $message, $options);
+        return call_user_func($this->process, $message, $options);
     }
 }

--- a/tests/Swarrot/Broker/MessageProvider/CallbackMessageProviderTest.php
+++ b/tests/Swarrot/Broker/MessageProvider/CallbackMessageProviderTest.php
@@ -1,0 +1,135 @@
+<?php
+
+namespace Swarrot\Tests\Broker\MessageProvider;
+
+use PHPUnit\Framework\TestCase;
+use Swarrot\Broker\Message;
+use Swarrot\Broker\MessageProvider\CallbackMessageProvider;
+
+class CallbackMessageProviderTest extends TestCase
+{
+    public function callable_with_message_provider()
+    {
+        return [
+            [
+                function () { return new Message(); },
+            ],
+            [
+                \Closure::fromCallable(function () { return new Message(); }),
+            ],
+            [
+                [
+                    new class() {
+                        public function get()
+                        {
+                            return new Message();
+                        }
+                    },
+                    'get',
+                ],
+            ],
+            [
+                new class() {
+                    public function __invoke()
+                    {
+                        return new Message();
+                    }
+                },
+            ],
+        ];
+    }
+
+    /**
+     * @dataProvider callable_with_message_provider
+     *
+     * @param $callableProvider
+     */
+    public function test_get_with_messages_in_queue_return_message($callableProvider)
+    {
+        $provider = new CallbackMessageProvider($callableProvider);
+        $message = $provider->get();
+
+        $this->assertInstanceOf(Message::class, $message);
+    }
+
+    public function callable_without_message_provider()
+    {
+        return [
+            [
+                function () { return null; },
+            ],
+            [
+                \Closure::fromCallable(function () { return null; }),
+            ],
+            [
+                [
+                    new class() {
+                        public function get()
+                        {
+                            return null;
+                        }
+                    },
+                    'get',
+                ],
+            ],
+            [
+                new class() {
+                    public function __invoke()
+                    {
+                        return null;
+                    }
+                },
+            ],
+        ];
+    }
+
+    /**
+     * @dataProvider callable_without_message_provider
+     *
+     * @param $callableProvider
+     */
+    public function test_get_without_messages_in_queue_return_null($callableProvider)
+    {
+        $provider = new CallbackMessageProvider($callableProvider);
+        $message = $provider->get();
+
+        $this->assertNull($message);
+    }
+
+    public function test_ack()
+    {
+        $message = new Message();
+        $ackMock = $this->prophesize(AckNackProvider::class);
+        $ackMock->ack($message)->shouldBeCalled();
+
+        $provider = new CallbackMessageProvider(function () {}, [$ackMock->reveal(), 'ack']);
+        $provider->ack($message);
+    }
+
+    public function test_nack()
+    {
+        $message = new Message();
+        $nackMock = $this->prophesize(AckNackProvider::class);
+        $nackMock->nack($message, false)->shouldBeCalled();
+
+        $provider = new CallbackMessageProvider(function () {}, function () {}, [$nackMock->reveal(), 'nack']);
+        $provider->nack($message);
+    }
+
+    public function test_get_name()
+    {
+        $provider = new CallbackMessageProvider(function () {});
+
+        $this->assertEquals('', $provider->getQueueName());
+    }
+}
+class AckNackProvider
+{
+    public function ack(Message $message)
+    {
+    }
+
+    public function nack(Message $message)
+    {
+    }
+}

--- a/tests/Swarrot/Processor/Callback/CallbackProcessorTest.php
+++ b/tests/Swarrot/Processor/Callback/CallbackProcessorTest.php
@@ -1,0 +1,73 @@
+<?php
+
+namespace Swarrot\Tests\Processor\Ack;
+
+use PHPUnit\Framework\TestCase;
+use Swarrot\Broker\Message;
+use Swarrot\Processor\Callback\CallbackProcessor;
+
+class CallbackProcessorTest extends TestCase
+{
+    public function callable_provider()
+    {
+        return [
+            [
+                function () { return 'fake_callable_return'; },
+            ],
+            [
+                \Closure::fromCallable(function () { return 'fake_callable_return'; }),
+            ],
+            [
+                [
+                    new class() {
+                        public function get()
+                        {
+                            return 'fake_callable_return';
+                        }
+                    },
+                    'get',
+                ],
+            ],
+            [
+                new class() {
+                    public function __invoke()
+                    {
+                        return 'fake_callable_return';
+                    }
+                },
+            ],
+        ];
+    }
+
+    /**
+     * @dataProvider callable_provider
+     *
+     * @param $callable
+     */
+    public function test_process($callable)
+    {
+        $callbackProcessor = new CallbackProcessor($callable);
+
+        $this->assertEquals('fake_callable_return', $callbackProcessor->process(new Message(), []));
+    }
+
+    public function test_process_args()
+    {
+        $message = new Message();
+        $options = ['fake_options_value'];
+
+        $fakeCallable = $this->prophesize(FakeCallable::class);
+        $fakeCallable->process($message, $options)->willReturn('fake_callable_return')->shouldBeCalled();
+
+        $callbackProcessor = new CallbackProcessor([$fakeCallable->reveal(), 'process']);
+
+        $this->assertEquals('fake_callable_return', $callbackProcessor->process($message, $options));
+    }
+}
+
+class FakeCallable
+{
+    public function process($message, $options)
+    {
+    }
+}


### PR DESCRIPTION
|**Q**|**A**|
| ------------- |:-------------:|
| Branch? | master|
| Bug fix? | no |
| New feature? | no |
| BC breaks? | no |
| Deprecations? | no |
| Tests pass? | yes |

Hi, hope you enjoy :)
Type closure is more restrictif than callable
 - enhance `CallbackProcessor` (replace \Closure by callable and fix some doc bloc)
 - enhance `CallbackMessageProvider`  (replace \Closure by callable and fix some doc bloc)
 - create the unit test for this 2 class

So now we can use with these syntaxt
```php
new CallbackProcessor(function () { /*your process code*/ });
```

```php
new CallbackProcessor(\Closure::fromCallable(function () {  /*your process code*/ })
```

```php
class MyProcessor
{
    public function process(Message $message, $options)
    {
        //your process code
    }
}
$myProcessor = new MyProcessor();
new CallbackProcessor([$myProcessor, 'get']);
```

```php
class MyProcessor
{
    public function __invoke(Message $message, $options)
    {
        //your process code
    }
}
new CallbackProcessor(new MyProcessor());
```