### PR TITLE
[PhpAmqpLibPublisher] Misbehaving header processing with PhpAmqpLib\AMQPArray

### DIFF
--- a/src/Swarrot/Broker/MessagePublisher/PhpAmqpLibMessagePublisher.php
+++ b/src/Swarrot/Broker/MessagePublisher/PhpAmqpLibMessagePublisher.php
@@ -58,7 +58,7 @@ class PhpAmqpLibMessagePublisher implements MessagePublisherInterface
                 $properties['application_headers'] = [];
             }
             foreach ($properties['headers'] as $header => $value) {
-                if (is_array($value) or ($value instanceof AMQPArray)) {
+                if (is_array($value) || $value instanceof AMQPArray) {
                     $type = 'A';
                 } elseif (is_int($value)) {
                     $type = 'I';

--- a/src/Swarrot/Broker/MessagePublisher/PhpAmqpLibMessagePublisher.php
+++ b/src/Swarrot/Broker/MessagePublisher/PhpAmqpLibMessagePublisher.php
@@ -4,6 +4,7 @@ namespace Swarrot\Broker\MessagePublisher;
 
 use PhpAmqpLib\Message\AMQPMessage;
 use PhpAmqpLib\Channel\AMQPChannel;
+use PhpAmqpLib\Wire\AMQPArray;
 use Swarrot\Broker\Message;
 
 class PhpAmqpLibMessagePublisher implements MessagePublisherInterface
@@ -57,7 +58,7 @@ class PhpAmqpLibMessagePublisher implements MessagePublisherInterface
                 $properties['application_headers'] = [];
             }
             foreach ($properties['headers'] as $header => $value) {
-                if (is_array($value)) {
+                if (is_array($value) or ($value instanceof AMQPArray)) {
                     $type = 'A';
                 } elseif (is_int($value)) {
                     $type = 'I';

--- a/tests/Swarrot/Broker/MessagePublisher/PhpAmqpLibMessagePublisherTest.php
+++ b/tests/Swarrot/Broker/MessagePublisher/PhpAmqpLibMessagePublisherTest.php
@@ -2,6 +2,7 @@
 
 namespace Swarrot\Tests\Broker\MessagePublisher;
 
+use PhpAmqpLib\Wire\AMQPArray;
 use Prophecy\Argument;
 use PhpAmqpLib\Message\AMQPMessage;
 use PHPUnit\Framework\TestCase;
@@ -47,6 +48,7 @@ class PhpAmqpLibMessagePublisherTest extends TestCase
                     $properties['application_headers']['int_header'] === ['I', 42] &&
                     $properties['application_headers']['string_header'] === ['S', 'my_value'] &&
                     $properties['application_headers']['array_header'] === ['A', ['foo' => 'bar']] &&
+                    $properties['application_headers']['x-death'] == ['A', new AMQPArray(['reason' => 'expired'])] &&
                     !isset($properties['headers']) &&
                     $message->serialize_properties()
                 ;
@@ -63,6 +65,7 @@ class PhpAmqpLibMessagePublisherTest extends TestCase
                     'headers' => [
                         'string_header' => 'my_value',
                         'array_header' => ['foo' => 'bar'],
+                        'x-death' => new AMQPArray(['reason' => 'expired']),
                     ],
                     'application_headers' => [
                         'int_header' => ['I', 42],

--- a/tests/Swarrot/Broker/MessagePublisher/PhpAmqpLibMessagePublisherTest.php
+++ b/tests/Swarrot/Broker/MessagePublisher/PhpAmqpLibMessagePublisherTest.php
@@ -56,6 +56,7 @@ class PhpAmqpLibMessagePublisherTest extends TestCase
                         $properties['application_headers']['x-death'] == ['A', new AMQPArray(['reason' => 'expired'])]
                     ;
                 }
+
                 return $res;
             }),
             Argument::exact('swarrot'),

--- a/tests/Swarrot/Broker/MessagePublisher/PhpAmqpLibMessagePublisherTest.php
+++ b/tests/Swarrot/Broker/MessagePublisher/PhpAmqpLibMessagePublisherTest.php
@@ -42,38 +42,43 @@ class PhpAmqpLibMessagePublisherTest extends TestCase
         $channel->basic_publish(
             Argument::that(function (AMQPMessage $message) {
                 $properties = $message->get_properties();
-
-                return
+                $res =
                     'body' === $message->body &&
                     $properties['application_headers']['int_header'] === ['I', 42] &&
                     $properties['application_headers']['string_header'] === ['S', 'my_value'] &&
                     $properties['application_headers']['array_header'] === ['A', ['foo' => 'bar']] &&
-                    $properties['application_headers']['x-death'] == ['A', new AMQPArray(['reason' => 'expired'])] &&
                     !isset($properties['headers']) &&
                     $message->serialize_properties()
                 ;
+                if (class_exists(AMQPArray::class)) {
+                    $res =
+                        $res &&
+                        $properties['application_headers']['x-death'] == ['A', new AMQPArray(['reason' => 'expired'])]
+                    ;
+                }
+                return $res;
             }),
             Argument::exact('swarrot'),
             Argument::exact('')
         )->shouldBeCalledTimes(1);
 
         $provider = new PhpAmqpLibMessagePublisher($channel->reveal(), 'swarrot');
-        $return = $provider->publish(
-            new Message(
-                'body',
-                [
-                    'headers' => [
-                        'string_header' => 'my_value',
-                        'array_header' => ['foo' => 'bar'],
-                        'x-death' => new AMQPArray(['reason' => 'expired']),
-                    ],
-                    'application_headers' => [
-                        'int_header' => ['I', 42],
-                    ],
-                ]
-            )
-        );
 
+        $properties = [
+            'headers' => [
+                'string_header' => 'my_value',
+                'array_header' => ['foo' => 'bar'],
+            ],
+            'application_headers' => [
+                'int_header' => ['I', 42],
+            ],
+        ];
+
+        if (class_exists(AMQPArray::class)) {
+            $properties['headers']['x-death'] = new AMQPArray(['reason' => 'expired']);
+        }
+
+        $return = $provider->publish(new Message('body', $properties));
         $this->assertNull($return);
     }
 


### PR DESCRIPTION
Hi!

**Description**

When using the RetryProcessor with PhpAmqpLibPublisher, I had the following error after the second retry :

```
mb_strlen() expects parameter 1 to be string, object given in /app/vendor/php-amqplib/php-amqplib/PhpAmqpLib/Wire/AMQPWriter.php on line 365
``` 

Related issue : https://github.com/swarrot/swarrot/issues/137

You can reproduce it with the files here : https://gist.github.com/claire-lovisa/724d5480ed4c2d812acef9faf0014523 _(versions used : php-amqp-lib 2.7, swarrot 3.2, rabbitmq 3.7)_

**Explanation**

It was due to a wrong type attribution when processing the headers given by RabbitMQ (x-death) after the first retry. In fact, PhpAmqpLib can give AMQPArray to Swarrot in the message headers and Swarrot attributed to it the 'S' type because AMQPArray != array. PhpAmqpLib\AMQPWriter was then not able to process the AMQPArray as a string.

Here's the way I fixed it, I hope it might be interesting for you too :)