### PR TITLE
[PhpAmqpLibPublisher][Fix 2.0] Misbehaving header processing with PhpAmqpLib\AMQPArray

### DIFF
--- a/src/Swarrot/Broker/MessageProvider/PhpAmqpLibMessageProvider.php
+++ b/src/Swarrot/Broker/MessageProvider/PhpAmqpLibMessageProvider.php
@@ -55,8 +55,8 @@ class PhpAmqpLibMessageProvider implements MessageProviderInterface
         $properties['headers'] = [];
         if ($envelope->has('application_headers')) {
             foreach ($envelope->get('application_headers') as $key => $value) {
-                if (is_a($value, AMQPArray::class)) {
-                    $properties['headers'][$key] = $value->getNativeData()[0];
+                if (is_a($value[1], AMQPArray::class)) {
+                    $properties['headers'][$key] = $value[1]->getNativeData();
                 } else {
                     $properties['headers'][$key] = $value[1];
                 }

--- a/src/Swarrot/Broker/MessageProvider/PhpAmqpLibMessageProvider.php
+++ b/src/Swarrot/Broker/MessageProvider/PhpAmqpLibMessageProvider.php
@@ -55,8 +55,8 @@ class PhpAmqpLibMessageProvider implements MessageProviderInterface
         $properties['headers'] = [];
         if ($envelope->has('application_headers')) {
             foreach ($envelope->get('application_headers') as $key => $value) {
-                if (is_a($value[1], AMQPArray::class)) {
-                    $properties['headers'][$key] = $value[1]->getNativeData();
+                if (is_a($value, AMQPArray::class)) {
+                    $properties['headers'][$key] = $value->getNativeData()[0];
                 } else {
                     $properties['headers'][$key] = $value[1];
                 }

--- a/src/Swarrot/Broker/MessageProvider/PhpAmqpLibMessageProvider.php
+++ b/src/Swarrot/Broker/MessageProvider/PhpAmqpLibMessageProvider.php
@@ -3,6 +3,7 @@
 namespace Swarrot\Broker\MessageProvider;
 
 use PhpAmqpLib\Channel\AMQPChannel;
+use PhpAmqpLib\Wire\AMQPArray;
 use Swarrot\Broker\Message;
 
 class PhpAmqpLibMessageProvider implements MessageProviderInterface
@@ -54,7 +55,11 @@ class PhpAmqpLibMessageProvider implements MessageProviderInterface
         $properties['headers'] = [];
         if ($envelope->has('application_headers')) {
             foreach ($envelope->get('application_headers') as $key => $value) {
-                $properties['headers'][$key] = $value[1];
+                if (is_a($value[1], AMQPArray::class)) {
+                    $properties['headers'][$key] = $value[1]->getNativeData();
+                } else {
+                    $properties['headers'][$key] = $value[1];
+                }
             }
         }
 

--- a/src/Swarrot/Broker/MessagePublisher/PhpAmqpLibMessagePublisher.php
+++ b/src/Swarrot/Broker/MessagePublisher/PhpAmqpLibMessagePublisher.php
@@ -58,7 +58,7 @@ class PhpAmqpLibMessagePublisher implements MessagePublisherInterface
                 $properties['application_headers'] = [];
             }
             foreach ($properties['headers'] as $header => $value) {
-                if (is_array($value) || $value instanceof AMQPArray) {
+                if (is_array($value)) {
                     $type = 'A';
                 } elseif (is_int($value)) {
                     $type = 'I';

--- a/tests/Swarrot/Broker/MessageProvider/PhpAmqpLibMessageProviderTest.php
+++ b/tests/Swarrot/Broker/MessageProvider/PhpAmqpLibMessageProviderTest.php
@@ -29,9 +29,19 @@ class PhpAmqpLibMessageProviderTest extends TestCase
     public function test_get_with_amqp_array_header_return_array_header()
     {
         $channel = $this->prophesize(AMQPChannel::class);
+
+        $properties = [
+            "application_headers" => [
+                "x-death" => [
+                    "0" => "S",
+                    "1" => new AMQPArray(["data:protected" => "data"])
+                ]
+            ]
+        ];
+
         $amqpMessage = new AMQPMessage(
-            'foobar',
-            ['application_headers' => ['x-death' => new AMQPArray(['reason' => 'expired'])]]
+            'hello',
+            $properties
         );
 
         $amqpMessage->delivery_info['delivery_tag'] = '1';
@@ -41,7 +51,7 @@ class PhpAmqpLibMessageProviderTest extends TestCase
         $provider = new PhpAmqpLibMessageProvider($channel->reveal(), 'my_queue');
         $message = $provider->get();
 
-        $this->assertEquals('expired', $message->getProperties()['headers']['x-death']);
+        $this->assertEquals(["0" => "data"], $message->getProperties()['headers']['x-death']);
     }
 
     public function test_get_without_messages_in_queue_return_null()

--- a/tests/Swarrot/Broker/MessageProvider/PhpAmqpLibMessageProviderTest.php
+++ b/tests/Swarrot/Broker/MessageProvider/PhpAmqpLibMessageProviderTest.php
@@ -28,30 +28,32 @@ class PhpAmqpLibMessageProviderTest extends TestCase
 
     public function test_get_with_amqp_array_header_return_array_header()
     {
-        $channel = $this->prophesize(AMQPChannel::class);
+        if (class_exists(AMQPArray::class)) {
+            $channel = $this->prophesize(AMQPChannel::class);
 
-        $properties = [
-            "application_headers" => [
-                "x-death" => [
-                    "0" => "S",
-                    "1" => new AMQPArray(["data:protected" => "data"])
+            $properties = [
+                "application_headers" => [
+                    "x-death" => [
+                        "0" => "S",
+                        "1" => new AMQPArray(["data:protected" => "data"])
+                    ]
                 ]
-            ]
-        ];
+            ];
 
-        $amqpMessage = new AMQPMessage(
-            'hello',
-            $properties
-        );
+            $amqpMessage = new AMQPMessage(
+                'hello',
+                $properties
+            );
 
-        $amqpMessage->delivery_info['delivery_tag'] = '1';
+            $amqpMessage->delivery_info['delivery_tag'] = '1';
 
-        $channel->basic_get('my_queue')->shouldBeCalled()->willReturn($amqpMessage);
+            $channel->basic_get('my_queue')->shouldBeCalled()->willReturn($amqpMessage);
 
-        $provider = new PhpAmqpLibMessageProvider($channel->reveal(), 'my_queue');
-        $message = $provider->get();
+            $provider = new PhpAmqpLibMessageProvider($channel->reveal(), 'my_queue');
+            $message = $provider->get();
 
-        $this->assertEquals(["0" => "data"], $message->getProperties()['headers']['x-death']);
+            $this->assertEquals(["0" => "data"], $message->getProperties()['headers']['x-death']);
+        }
     }
 
     public function test_get_without_messages_in_queue_return_null()


### PR DESCRIPTION
This PR is the continuation of [#174](https://github.com/swarrot/swarrot/pull/174).

As suggested by @stof, instead of correcting the publisher, we can fix the provider so that we always have array in the Swarrot message, not sometimes an array and sometimes an AMQPArray. 

I removed here the previous fix (and corresponding test) and then I fixed the provider and added a test case.