### PR TITLE
Allow building more exotic retry routing keys for advanced usage

### DIFF
--- a/src/Swarrot/Processor/Retry/README.md
+++ b/src/Swarrot/Processor/Retry/README.md
@@ -1,16 +1,19 @@
 # RetryProcessor
 
-Retryprocessor is a [swarrot](https://github.com/swarrot/swarrot) processor.
+RetryProcessor is a [swarrot](https://github.com/swarrot/swarrot) processor.
 Its goal is to re-published messages in broker when an error occurred.
 
 ## Configuration
 
-|Key                      |Default|Description                                                                  |
-|:-----------------------:|:-----:|-----------------------------------------------------------------------------|
-|retry_key_pattern        |       |[MANDATORY] The pattern to use to construct routing key (ie: `key_%attempt%`)|
-|retry_attempts           |3      |The number of attempts before raising an exception.                          |
-|retry_log_levels_map     |[]     |Map of classes to a log level when retry. (Warning by default)               |
-|retry_fail_log_levels_map|[]     |Map of classes to a log level when all retries failed. (Warning by default)  |
+|Key                      |Default|Description                                                                           |
+|:-----------------------:|:-----:|--------------------------------------------------------------------------------------|
+|retry_key_pattern        |       |The pattern to use to construct routing key (ie: `key_%attempt%`)                     |
+|retry_key_generator      |       |The callable to construct routing key (ie: `(int $attempt, Message $message): string`)|
+|retry_attempts           |3      |The number of attempts before raising an exception.                                   |
+|retry_log_levels_map     |[]     |Map of classes to a log level when retry. (Warning by default)                        |
+|retry_fail_log_levels_map|[]     |Map of classes to a log level when all retries failed. (Warning by default)           |
+
+Configuring either `retry_key_pattern` or `retry_key_generator` is mandatory.
 
 ## How it works
 

--- a/src/Swarrot/Processor/Retry/RetryProcessor.php
+++ b/src/Swarrot/Processor/Retry/RetryProcessor.php
@@ -59,7 +59,7 @@ class RetryProcessor implements ConfigurableInterface
                     return function ($attempts) use ($keyPattern) {
                         return str_replace('%attempt%', $attempts, $keyPattern);
                     };
-                }
+                },
             ))
             ->setDefined(array(
                 'retry_key_pattern', // Mandatory if retry_key_generator is not provided

--- a/src/Swarrot/Processor/Retry/RetryProcessor.php
+++ b/src/Swarrot/Processor/Retry/RetryProcessor.php
@@ -7,6 +7,8 @@ use Swarrot\Processor\ConfigurableInterface;
 use Swarrot\Broker\Message;
 use Psr\Log\LoggerInterface;
 use Psr\Log\LogLevel;
+use Symfony\Component\OptionsResolver\Exception\MissingOptionsException;
+use Symfony\Component\OptionsResolver\Options;
 use Symfony\Component\OptionsResolver\OptionsResolver;
 use Swarrot\Broker\MessagePublisher\MessagePublisherInterface;
 
@@ -47,12 +49,24 @@ class RetryProcessor implements ConfigurableInterface
                 'retry_attempts' => 3,
                 'retry_log_levels_map' => array(),
                 'retry_fail_log_levels_map' => array(),
+                'retry_key_generator' => function (Options $options) {
+                    if (!isset($options['retry_key_pattern'])) {
+                        throw new MissingOptionsException('Either the retry_key_pattern or retry_key_generator option is required.');
+                    }
+
+                    $keyPattern = $options['retry_key_pattern'];
+
+                    return function ($attempts) use ($keyPattern) {
+                        return str_replace('%attempt%', $attempts, $keyPattern);
+                    };
+                }
             ))
-            ->setRequired(array(
-                'retry_key_pattern',
+            ->setDefined(array(
+                'retry_key_pattern', // Mandatory if retry_key_generator is not provided
             ))
             ->setAllowedTypes('retry_attempts', 'int')
             ->setAllowedTypes('retry_key_pattern', 'string')
+            ->setAllowedTypes('retry_key_generator', 'callable')
             ->setAllowedTypes('retry_log_levels_map', 'array')
             ->setAllowedTypes('retry_fail_log_levels_map', 'array')
         ;
@@ -92,12 +106,14 @@ class RetryProcessor implements ConfigurableInterface
 
         $properties['headers']['swarrot_retry_attempts'] = $attempts;
 
+        $keyGenerator = $options['retry_key_generator'];
+
+        $key = $keyGenerator($attempts, $message);
+
         $message = new Message(
             $message->getBody(),
             $properties
         );
-
-        $key = str_replace('%attempt%', $attempts, $options['retry_key_pattern']);
 
         $this->logger and $this->logException(
             $exception,

--- a/tests/Swarrot/Processor/Retry/RetryProcessorTest.php
+++ b/tests/Swarrot/Processor/Retry/RetryProcessorTest.php
@@ -58,12 +58,18 @@ class RetryProcessorTest extends TestCase
         $logger = $this->prophesize(LoggerInterface::class);
 
         $message = new Message('body', array(), 1);
-        $options = array(
+
+        $retryProcessor = new RetryProcessor($processor->reveal(), $messagePublisher->reveal(), $logger->reveal());
+
+        $optionsResolver = new OptionsResolver();
+        $retryProcessor->setDefaultOptions($optionsResolver);
+
+        $options = $optionsResolver->resolve(array(
             'retry_attempts' => 3,
             'retry_key_pattern' => 'key_%attempt%',
             'retry_log_levels_map' => array(),
             'retry_fail_log_levels_map' => array(),
-        );
+        ));
 
         $processor
             ->process(
@@ -81,10 +87,8 @@ class RetryProcessorTest extends TestCase
             ->shouldBeCalledTimes(1)
         ;
 
-        $processor = new RetryProcessor($processor->reveal(), $messagePublisher->reveal(), $logger->reveal());
-
         $this->assertNull(
-            $processor->process($message, $options)
+            $retryProcessor->process($message, $options)
         );
     }
 
@@ -96,12 +100,17 @@ class RetryProcessorTest extends TestCase
 
         $message = new Message('body', array('headers' => array('swarrot_retry_attempts' => 1)), 1);
 
-        $options = array(
+        $retryProcessor = new RetryProcessor($processor->reveal(), $messagePublisher->reveal(), $logger->reveal());
+
+        $optionsResolver = new OptionsResolver();
+        $retryProcessor->setDefaultOptions($optionsResolver);
+
+        $options = $optionsResolver->resolve(array(
             'retry_attempts' => 3,
             'retry_key_pattern' => 'key_%attempt%',
             'retry_log_levels_map' => array(),
             'retry_fail_log_levels_map' => array(),
-        );
+        ));
 
         $processor
             ->process(
@@ -124,10 +133,8 @@ class RetryProcessorTest extends TestCase
             ->shouldBeCalledTimes(1)
         ;
 
-        $processor = new RetryProcessor($processor->reveal(), $messagePublisher->reveal(), $logger->reveal());
-
         $this->assertNull(
-            $processor->process($message, $options)
+            $retryProcessor->process($message, $options)
         );
     }
 
@@ -138,12 +145,18 @@ class RetryProcessorTest extends TestCase
         $logger = $this->prophesize(LoggerInterface::class);
 
         $message = new Message('body', array('headers' => array('swarrot_retry_attempts' => 3)), 1);
-        $options = array(
+
+        $retryProcessor = new RetryProcessor($processor->reveal(), $messagePublisher->reveal(), $logger->reveal());
+
+        $optionsResolver = new OptionsResolver();
+        $retryProcessor->setDefaultOptions($optionsResolver);
+
+        $options = $optionsResolver->resolve(array(
             'retry_attempts' => 3,
             'retry_key_pattern' => 'key_%attempt%',
             'retry_log_levels_map' => array(),
             'retry_fail_log_levels_map' => array(),
-        );
+        ));
 
         $processor
             ->process(
@@ -161,9 +174,8 @@ class RetryProcessorTest extends TestCase
         ;
 
         $this->expectException('\BadMethodCallException');
-        $processor = new RetryProcessor($processor->reveal(), $messagePublisher->reveal(), $logger->reveal());
 
-        $processor->process($message, $options);
+        $retryProcessor->process($message, $options);
     }
 
     public function test_it_should_return_a_valid_array_of_option()
@@ -196,12 +208,17 @@ class RetryProcessorTest extends TestCase
 
         $message = new Message('body', array('delivery_mode' => 2, 'app_id' => 'applicationId', 'headers' => array('swarrot_retry_attempts' => 1)), 1);
 
-        $options = array(
+        $retryProcessor = new RetryProcessor($processor->reveal(), $messagePublisher->reveal(), $logger->reveal());
+
+        $optionsResolver = new OptionsResolver();
+        $retryProcessor->setDefaultOptions($optionsResolver);
+
+        $options = $optionsResolver->resolve(array(
             'retry_attempts' => 3,
             'retry_key_pattern' => 'key_%attempt%',
             'retry_log_levels_map' => array(),
             'retry_fail_log_levels_map' => array(),
-        );
+        ));
 
         $processor
             ->process(
@@ -225,10 +242,8 @@ class RetryProcessorTest extends TestCase
             ->shouldBeCalledTimes(1)
         ;
 
-        $processor = new RetryProcessor($processor->reveal(), $messagePublisher->reveal(), $logger->reveal());
-
         $this->assertNull(
-            $processor->process($message, $options)
+            $retryProcessor->process($message, $options)
         );
     }
 
@@ -243,12 +258,17 @@ class RetryProcessorTest extends TestCase
             'integer' => 42,
         )), 1);
 
-        $options = array(
+        $retryProcessor = new RetryProcessor($processor->reveal(), $messagePublisher->reveal(), $logger->reveal());
+
+        $optionsResolver = new OptionsResolver();
+        $retryProcessor->setDefaultOptions($optionsResolver);
+
+        $options = $optionsResolver->resolve(array(
             'retry_attempts' => 3,
             'retry_key_pattern' => 'key_%attempt%',
             'retry_log_levels_map' => array(),
             'retry_fail_log_levels_map' => array(),
-        );
+        ));
 
         $processor
             ->process(
@@ -271,10 +291,8 @@ class RetryProcessorTest extends TestCase
             ->shouldBeCalledTimes(1)
         ;
 
-        $processor = new RetryProcessor($processor->reveal(), $messagePublisher->reveal(), $logger->reveal());
-
         $this->assertNull(
-            $processor->process($message, $options)
+            $retryProcessor->process($message, $options)
         );
     }
 
@@ -286,12 +304,18 @@ class RetryProcessorTest extends TestCase
         $exception = new \BadMethodCallException();
 
         $message = new Message('body', array(), 1);
-        $options = array(
+
+        $retryProcessor = new RetryProcessor($processor->reveal(), $messagePublisher->reveal(), $logger->reveal());
+
+        $optionsResolver = new OptionsResolver();
+        $retryProcessor->setDefaultOptions($optionsResolver);
+
+        $options = $optionsResolver->resolve(array(
             'retry_attempts' => 3,
             'retry_key_pattern' => 'key_%attempt%',
             'retry_log_levels_map' => array(),
             'retry_fail_log_levels_map' => array(),
-        );
+        ));
 
         $processor
             ->process(
@@ -313,10 +337,8 @@ class RetryProcessorTest extends TestCase
             ->shouldBeCalledTimes(1)
         ;
 
-        $processor = new RetryProcessor($processor->reveal(), $messagePublisher->reveal(), $logger->reveal());
-
         $this->assertNull(
-            $processor->process($message, $options)
+            $retryProcessor->process($message, $options)
         );
     }
 
@@ -328,14 +350,20 @@ class RetryProcessorTest extends TestCase
         $exception = new \BadMethodCallException();
 
         $message = new Message('body', array(), 1);
-        $options = array(
+
+        $retryProcessor = new RetryProcessor($processor->reveal(), $messagePublisher->reveal(), $logger->reveal());
+
+        $optionsResolver = new OptionsResolver();
+        $retryProcessor->setDefaultOptions($optionsResolver);
+
+        $options = $optionsResolver->resolve(array(
             'retry_attempts' => 3,
             'retry_key_pattern' => 'key_%attempt%',
             'retry_log_levels_map' => array(
                 '\BadMethodCallException' => LogLevel::CRITICAL,
             ),
             'retry_fail_log_levels_map' => array(),
-        );
+        ));
 
         $processor
             ->process(
@@ -357,10 +385,8 @@ class RetryProcessorTest extends TestCase
             ->shouldBeCalledTimes(1)
         ;
 
-        $processor = new RetryProcessor($processor->reveal(), $messagePublisher->reveal(), $logger->reveal());
-
         $this->assertNull(
-            $processor->process($message, $options)
+            $retryProcessor->process($message, $options)
         );
     }
 
@@ -372,14 +398,20 @@ class RetryProcessorTest extends TestCase
         $exception = new \BadMethodCallException();
 
         $message = new Message('body', array(), 1);
-        $options = array(
+
+        $retryProcessor = new RetryProcessor($processor->reveal(), $messagePublisher->reveal(), $logger->reveal());
+
+        $optionsResolver = new OptionsResolver();
+        $retryProcessor->setDefaultOptions($optionsResolver);
+
+        $options = $optionsResolver->resolve(array(
             'retry_attempts' => 3,
             'retry_key_pattern' => 'key_%attempt%',
             'retry_log_levels_map' => array(
                 '\LogicException' => LogLevel::CRITICAL,
             ),
             'retry_fail_log_levels_map' => array(),
-        );
+        ));
 
         $processor
             ->process(
@@ -401,10 +433,8 @@ class RetryProcessorTest extends TestCase
             ->shouldBeCalledTimes(1)
         ;
 
-        $processor = new RetryProcessor($processor->reveal(), $messagePublisher->reveal(), $logger->reveal());
-
         $this->assertNull(
-            $processor->process($message, $options)
+            $retryProcessor->process($message, $options)
         );
     }
 
@@ -416,12 +446,18 @@ class RetryProcessorTest extends TestCase
         $exception = new \BadMethodCallException();
 
         $message = new Message('body', array('headers' => array('swarrot_retry_attempts' => 3)), 1);
-        $options = array(
+
+        $retryProcessor = new RetryProcessor($processor->reveal(), $messagePublisher->reveal(), $logger->reveal());
+
+        $optionsResolver = new OptionsResolver();
+        $retryProcessor->setDefaultOptions($optionsResolver);
+
+        $options = $optionsResolver->resolve(array(
             'retry_attempts' => 3,
             'retry_key_pattern' => 'key_%attempt%',
             'retry_log_levels_map' => array(),
             'retry_fail_log_levels_map' => array(),
-        );
+        ));
 
         $processor
             ->process(
@@ -444,9 +480,8 @@ class RetryProcessorTest extends TestCase
         ;
 
         $this->expectException('\BadMethodCallException');
-        $processor = new RetryProcessor($processor->reveal(), $messagePublisher->reveal(), $logger->reveal());
 
-        $processor->process($message, $options);
+        $retryProcessor->process($message, $options);
     }
 
     public function test_it_should_log_a_custom_log_level_if_max_attempts_is_reached()
@@ -457,14 +492,20 @@ class RetryProcessorTest extends TestCase
         $exception = new \BadMethodCallException();
 
         $message = new Message('body', array('headers' => array('swarrot_retry_attempts' => 3)), 1);
-        $options = array(
+
+        $retryProcessor = new RetryProcessor($processor->reveal(), $messagePublisher->reveal(), $logger->reveal());
+
+        $optionsResolver = new OptionsResolver();
+        $retryProcessor->setDefaultOptions($optionsResolver);
+
+        $options = $optionsResolver->resolve(array(
             'retry_attempts' => 3,
             'retry_key_pattern' => 'key_%attempt%',
             'retry_log_levels_map' => array(),
             'retry_fail_log_levels_map' => array(
                 '\BadMethodCallException' => LogLevel::CRITICAL,
             ),
-        );
+        ));
 
         $processor
             ->process(
@@ -487,9 +528,8 @@ class RetryProcessorTest extends TestCase
         ;
 
         $this->expectException('\BadMethodCallException');
-        $processor = new RetryProcessor($processor->reveal(), $messagePublisher->reveal(), $logger->reveal());
 
-        $processor->process($message, $options);
+        $retryProcessor->process($message, $options);
     }
 
     public function test_it_should_log_a_custom_log_level_if_max_attempts_is_reached_for_child_exception()
@@ -500,14 +540,20 @@ class RetryProcessorTest extends TestCase
         $exception = new \BadMethodCallException();
 
         $message = new Message('body', array('headers' => array('swarrot_retry_attempts' => 3)), 1);
-        $options = array(
+
+        $retryProcessor = new RetryProcessor($processor->reveal(), $messagePublisher->reveal(), $logger->reveal());
+
+        $optionsResolver = new OptionsResolver();
+        $retryProcessor->setDefaultOptions($optionsResolver);
+
+        $options = $optionsResolver->resolve(array(
             'retry_attempts' => 3,
             'retry_key_pattern' => 'key_%attempt%',
             'retry_log_levels_map' => array(),
             'retry_fail_log_levels_map' => array(
                 '\LogicException' => LogLevel::CRITICAL,
             ),
-        );
+        ));
 
         $processor
             ->process(
@@ -530,8 +576,7 @@ class RetryProcessorTest extends TestCase
         ;
 
         $this->expectException('\BadMethodCallException');
-        $processor = new RetryProcessor($processor->reveal(), $messagePublisher->reveal(), $logger->reveal());
 
-        $processor->process($message, $options);
+        $retryProcessor->process($message, $options);
     }
 }

--- a/tests/Swarrot/Processor/Retry/RetryProcessorTest.php
+++ b/tests/Swarrot/Processor/Retry/RetryProcessorTest.php
@@ -10,6 +10,7 @@ use Swarrot\Broker\Message;
 use Swarrot\Broker\MessagePublisher\MessagePublisherInterface;
 use Swarrot\Processor\ProcessorInterface;
 use Swarrot\Processor\Retry\RetryProcessor;
+use Symfony\Component\OptionsResolver\Exception\MissingOptionsException;
 use Symfony\Component\OptionsResolver\OptionsResolver;
 
 class RetryProcessorTest extends TestCase
@@ -252,6 +253,21 @@ class RetryProcessorTest extends TestCase
             'retry_log_levels_map' => array(),
             'retry_fail_log_levels_map' => array(),
         ), $config);
+    }
+
+    public function test_it_should_require_configuring_the_retry_key()
+    {
+        $processor = $this->prophesize(ProcessorInterface::class);
+        $messagePublisher = $this->prophesize(MessagePublisherInterface::class);
+
+        $retryProcessor = new RetryProcessor($processor->reveal(), $messagePublisher->reveal());
+
+        $optionsResolver = new OptionsResolver();
+        $retryProcessor->setDefaultOptions($optionsResolver);
+
+        $this->expectException(MissingOptionsException::class);
+
+        $optionsResolver->resolve(array());
     }
 
     public function test_it_should_keep_original_message_properties()


### PR DESCRIPTION
A new `retry_key_generator` option allows passing a callable to build the retry routing key in case replacing the attempt number in a static pattern is not enough.
The callable receives the attempt number as first argument and the processed message as second argument, and must return a string for the retry routing key. The default value of that option is a callable using the `retry_key_pattern` option, which is now required only when the callable is not provided explicitly.

I'm currently trying to build a worker which consumes messages from a main queue and from a lower priority queue (`get` takes message from the main queue if there is one, and otherwise takes on in the lower priority queue). This worked mostly fine. Thanks to some convention in my app, I'm able to find about which of the wrapped providers I should use to forward the `ack` or `nack` call. The only missing point I had was the retry mechanism, where I would need to change the retry key depending on the Message being handled. That new extension point allows me to do that.