### PR TITLE
Upgrade ext-amqp on CI

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -12,7 +12,7 @@ addons:
 env:
     global:
         - LIBRABBITMQ_VERSION=v0.8.0
-        - PHPAMQP_VERSION=v1.9.3
+        - PHPAMQP_VERSION=v1.9.4
         - MODE="test" # Allowed values: [test, syntax]
 
 matrix:

--- a/.travis.yml
+++ b/.travis.yml
@@ -16,17 +16,12 @@ env:
         - MODE="test" # Allowed values: [test, syntax]
 
 matrix:
-    allow_failures:
-        - php: nightly
-
     include:
         # Test with default configuration
         - { php: 7.2 }
         - { php: 7.3 }
-        - { php: nightly }
         # Test against librabbitmq cutting-edge
         - { php: 7.2, env: LIBRABBITMQ_VERSION=master }
-        - { php: nightly, env: LIBRABBITMQ_VERSION=master }
         # Test with lowest & beta dependencies
         - { php: 7.2, env: COMPOSER_FLAGS='--prefer-lowest --prefer-stable' }
         - { php: 7.2, env: DEPENDENCIES=beta }

--- a/.travis.yml
+++ b/.travis.yml
@@ -22,6 +22,7 @@ matrix:
     include:
         # Test with default configuration
         - { php: 7.2 }
+        - { php: 7.3 }
         - { php: nightly }
         # Test against librabbitmq cutting-edge
         - { php: 7.2, env: LIBRABBITMQ_VERSION=master }


### PR DESCRIPTION
The `php: nightly` jobs were failing to compile ext-amqp. This is an attempt at fixing it (it should at least allow having a working PHP 7.3 job when we add it, if not nightly)