### PR TITLE
Use static log messages

### DIFF
--- a/src/Swarrot/Consumer.php
+++ b/src/Swarrot/Consumer.php
@@ -55,10 +55,9 @@ class Consumer
      */
     public function consume(array $options = array())
     {
-        $this->logger->debug(sprintf(
-            'Start consuming queue %s.',
-            $this->messageProvider->getQueueName()
-        ));
+        $this->logger->debug('Start consuming queue.', [
+            'queue' => $this->messageProvider->getQueueName(),
+        ]);
 
         $this->optionsResolver->setDefaults(array(
             'poll_interval' => 50000,

--- a/src/Swarrot/Processor/Ack/AckProcessor.php
+++ b/src/Swarrot/Processor/Ack/AckProcessor.php
@@ -49,8 +49,9 @@ class AckProcessor implements ConfigurableInterface
             $this->messageProvider->ack($message);
 
             $this->logger->info(
-                '[Ack] Message #'.$message->getId().' has been correctly ack\'ed',
+                "[Ack] Message has been correctly ack'ed",
                 [
+                    'message_id' => $message->getId(),
                     'swarrot_processor' => 'ack',
                 ]
             );
@@ -87,12 +88,10 @@ class AckProcessor implements ConfigurableInterface
         $this->messageProvider->nack($message, $requeue);
 
         $this->logger->error(
-            sprintf(
-                '[Ack] An exception occurred. Message #%d has been %s.',
-                $message->getId(),
-                $requeue ? 'requeued' : 'nack\'ed'
-            ),
+            '[Ack] An exception occurred.',
             [
+                'message_id' => $message->getId(),
+                'message_status' => $requeue ? 'requeued' : "nack'ed",
                 'swarrot_processor' => 'ack',
                 'exception' => $exception,
             ]

--- a/src/Swarrot/Processor/InstantRetry/InstantRetryProcessor.php
+++ b/src/Swarrot/Processor/InstantRetry/InstantRetryProcessor.php
@@ -69,12 +69,12 @@ class InstantRetryProcessor implements ConfigurableInterface
     {
         $this->logException(
             $exception,
-            sprintf(
-                '[InstantRetry] An exception occurred. Message #%d will be processed again in %d ms',
-                $message->getId(),
-                $options['instant_retry_delay'] / 1000
-            ),
-            $options['instant_retry_log_levels_map']
+            '[InstantRetry] An exception occurred. The message will be processed again.',
+            $options['instant_retry_log_levels_map'],
+            [
+                'message_id' => $message->getId(),
+                'instant_retry_delay' => $options['instant_retry_delay'] / 1000,
+            ]
         );
 
         usleep($options['instant_retry_delay']);
@@ -82,11 +82,13 @@ class InstantRetryProcessor implements ConfigurableInterface
 
     /**
      * @param \Exception|\Throwable $exception
-     * @param string                $logMessage
-     * @param array                 $logLevelsMap
      */
-    private function logException($exception, $logMessage, array $logLevelsMap)
-    {
+    private function logException(
+        $exception,
+        $logMessage,
+        array $logLevelsMap,
+        array $extraContext
+    ) {
         $logLevel = LogLevel::WARNING;
 
         foreach ($logLevelsMap as $className => $level) {
@@ -103,7 +105,7 @@ class InstantRetryProcessor implements ConfigurableInterface
             [
                 'swarrot_processor' => 'instant_retry',
                 'exception' => $exception,
-            ]
+            ] + $extraContext
         );
     }
 }

--- a/src/Swarrot/Processor/MaxExecutionTime/MaxExecutionTimeProcessor.php
+++ b/src/Swarrot/Processor/MaxExecutionTime/MaxExecutionTimeProcessor.php
@@ -91,15 +91,10 @@ class MaxExecutionTimeProcessor implements ConfigurableInterface, InitializableI
     protected function isTimeExceeded(array $options)
     {
         if (microtime(true) - $this->startTime > $options['max_execution_time']) {
-            $this->logger->info(
-                sprintf(
-                    '[MaxExecutionTime] Max execution time have been reached (%d)',
-                    $options['max_execution_time']
-                ),
-                [
-                    'swarrot_processor' => 'max_execution_time',
-                ]
-            );
+            $this->logger->info('[MaxExecutionTime] Max execution time has been reached', [
+                'max_execution_time' => $options['max_execution_time'],
+                'swarrot_processor' => 'max_execution_time',
+            ]);
 
             return true;
         }

--- a/src/Swarrot/Processor/MaxMessages/MaxMessagesProcessor.php
+++ b/src/Swarrot/Processor/MaxMessages/MaxMessagesProcessor.php
@@ -45,8 +45,9 @@ class MaxMessagesProcessor implements ConfigurableInterface
 
         if (++$this->messagesProcessed >= $options['max_messages']) {
             $this->logger->info(
-                sprintf('[MaxMessages] Max messages have been reached (%d)', $options['max_messages']),
+                '[MaxMessages] The maximum number of messages has been reached',
                 [
+                    'max_messages' => $options['max_messages'],
                     'swarrot_processor' => 'max_messages',
                 ]
             );

--- a/src/Swarrot/Processor/MemoryLimit/MemoryLimitProcessor.php
+++ b/src/Swarrot/Processor/MemoryLimit/MemoryLimitProcessor.php
@@ -40,8 +40,9 @@ class MemoryLimitProcessor implements ConfigurableInterface
 
         if (null !== $options['memory_limit'] && memory_get_usage() >= $options['memory_limit'] * 1024 * 1024) {
             $this->logger->info(
-                sprintf('[MemoryLimit] Memory limit has been reached (%d MB)', $options['memory_limit']),
+                '[MemoryLimit] Memory limit has been reached (%d MB)',
                 [
+                    'memory_limit' => $options['memory_limit'],
                     'swarrot_processor' => 'memory_limit',
                 ]
             );

--- a/src/Swarrot/Processor/RPC/RpcServerProcessor.php
+++ b/src/Swarrot/Processor/RPC/RpcServerProcessor.php
@@ -42,7 +42,11 @@ class RpcServerProcessor implements ProcessorInterface
             return $result;
         }
 
-        $this->logger->info(sprintf('sending a new message to the "%s" queue with the id "%s"', $properties['reply_to'], $properties['correlation_id']), ['swarrot_processor' => 'rpc']);
+        $this->logger->info('sending a new message', [
+            'swarrot_processor' => 'rpc',
+            'queue' => $properties['reply_to'],
+            'correlation_id' => $properties['correlation_id'],
+        ]);
 
         $message = new Message((string) $result, ['correlation_id' => $properties['correlation_id']]);
         $this->publisher->publish($message, $properties['reply_to']);

--- a/src/Swarrot/Processor/Retry/RetryProcessor.php
+++ b/src/Swarrot/Processor/Retry/RetryProcessor.php
@@ -90,11 +90,9 @@ class RetryProcessor implements ConfigurableInterface
         if ($attempts > $options['retry_attempts']) {
             $this->logger and $this->logException(
                 $exception,
-                sprintf(
-                    '[Retry] Stop attempting to process message after %d attempts',
-                    $attempts
-                ),
-                $options['retry_fail_log_levels_map']
+                '[Retry] Stop attempting to process message.',
+                $options['retry_fail_log_levels_map'],
+                ['number_of_attempts' => $attempts]
             );
 
             throw $exception;
@@ -117,12 +115,12 @@ class RetryProcessor implements ConfigurableInterface
 
         $this->logger and $this->logException(
             $exception,
-            sprintf(
-                '[Retry] An exception occurred. Republish message for the %d times (key: %s)',
-                $attempts,
-                $key
-            ),
-            $options['retry_log_levels_map']
+            '[Retry] An exception occurred. Republishing message.',
+            $options['retry_log_levels_map'],
+            [
+                'number_of_attempts' => $attempts,
+                'key' => $key,
+            ]
         );
 
         $this->publisher->publish($message, $key);
@@ -133,8 +131,12 @@ class RetryProcessor implements ConfigurableInterface
      * @param string                $logMessage
      * @param array                 $logLevelsMap
      */
-    private function logException($exception, $logMessage, array $logLevelsMap)
-    {
+    private function logException(
+        $exception,
+        $logMessage,
+        array $logLevelsMap,
+        array $extraContext
+    ) {
         $logLevel = LogLevel::WARNING;
 
         foreach ($logLevelsMap as $className => $level) {
@@ -151,7 +153,7 @@ class RetryProcessor implements ConfigurableInterface
             [
                 'swarrot_processor' => 'retry',
                 'exception' => $exception,
-            ]
+            ] + $extraContext
         );
     }
 }

--- a/tests/Swarrot/Processor/InstantRetry/InstantRetryProcessorTest.php
+++ b/tests/Swarrot/Processor/InstantRetry/InstantRetryProcessorTest.php
@@ -97,10 +97,12 @@ class InstantRetryProcessorTest extends TestCase
         $logger
             ->log(
                 Argument::exact(LogLevel::WARNING),
-                Argument::exact('[InstantRetry] An exception occurred. Message #1 will be processed again in 1 ms'),
+                Argument::exact('[InstantRetry] An exception occurred. The message will be processed again.'),
                 Argument::exact(array(
                     'swarrot_processor' => 'instant_retry',
                     'exception' => $exception,
+                    'message_id' => 1,
+                    'instant_retry_delay' => 1,
                 ))
             )
             ->shouldBeCalledTimes(3)
@@ -140,10 +142,12 @@ class InstantRetryProcessorTest extends TestCase
         $logger
             ->log(
                 Argument::exact(LogLevel::CRITICAL),
-                Argument::exact('[InstantRetry] An exception occurred. Message #1 will be processed again in 1 ms'),
+                Argument::exact('[InstantRetry] An exception occurred. The message will be processed again.'),
                 Argument::exact(array(
                     'swarrot_processor' => 'instant_retry',
                     'exception' => $exception,
+                    'message_id' => 1,
+                    'instant_retry_delay' => 1,
                 ))
             )
             ->shouldBeCalledTimes(3)
@@ -185,10 +189,12 @@ class InstantRetryProcessorTest extends TestCase
         $logger
             ->log(
                 Argument::exact(LogLevel::CRITICAL),
-                Argument::exact('[InstantRetry] An exception occurred. Message #1 will be processed again in 1 ms'),
+                Argument::exact('[InstantRetry] An exception occurred. The message will be processed again.'),
                 Argument::exact(array(
                     'swarrot_processor' => 'instant_retry',
                     'exception' => $exception,
+                    'message_id' => 1,
+                    'instant_retry_delay' => 1,
                 ))
             )
             ->shouldBeCalledTimes(3)

--- a/tests/Swarrot/Processor/MaxExecutionTime/MaxExecutionTimeProcessorTest.php
+++ b/tests/Swarrot/Processor/MaxExecutionTime/MaxExecutionTimeProcessorTest.php
@@ -41,8 +41,11 @@ class MaxExecutionTimeProcessorTest extends TestCase
 
         $logger = $this->prophesize(LoggerInterface::class);
         $logger->info(
-            Argument::exact(sprintf('[MaxExecutionTime] Max execution time have been reached (%d)', $maxExecutionTime)),
-            Argument::exact(['swarrot_processor' => 'max_execution_time'])
+            Argument::exact('[MaxExecutionTime] Max execution time has been reached'),
+            Argument::exact([
+                'max_execution_time' => $maxExecutionTime,
+                'swarrot_processor' => 'max_execution_time',
+            ])
         )
         ->shouldBeCalledTimes(1);
 

--- a/tests/Swarrot/Processor/MaxMessages/MaxMessagesProcessorTest.php
+++ b/tests/Swarrot/Processor/MaxMessages/MaxMessagesProcessorTest.php
@@ -42,8 +42,8 @@ class MaxMessagesProcessorTest extends TestCase
 
         $logger = $this->prophesize(LoggerInterface::class);
         $logger->info(
-            Argument::exact(sprintf('[MaxMessages] Max messages have been reached (%d)', $maxMessages)),
-            Argument::exact(['swarrot_processor' => 'max_messages'])
+            Argument::exact('[MaxMessages] The maximum number of messages has been reached'),
+            Argument::exact(['max_messages' => 2, 'swarrot_processor' => 'max_messages'])
         )
         ->shouldBeCalledTimes(1);
 

--- a/tests/Swarrot/Processor/Retry/RetryProcessorTest.php
+++ b/tests/Swarrot/Processor/Retry/RetryProcessorTest.php
@@ -398,10 +398,12 @@ class RetryProcessorTest extends TestCase
         $logger
             ->log(
                 Argument::exact(LogLevel::WARNING),
-                Argument::exact('[Retry] An exception occurred. Republish message for the 1 times (key: key_1)'),
+                Argument::exact('[Retry] An exception occurred. Republishing message.'),
                 Argument::exact(array(
                     'swarrot_processor' => 'retry',
                     'exception' => $exception,
+                    'number_of_attempts' => 1,
+                    'key' => 'key_1',
                 ))
             )
             ->shouldBeCalledTimes(1)
@@ -446,10 +448,12 @@ class RetryProcessorTest extends TestCase
         $logger
             ->log(
                 Argument::exact(LogLevel::CRITICAL),
-                Argument::exact('[Retry] An exception occurred. Republish message for the 1 times (key: key_1)'),
+                Argument::exact('[Retry] An exception occurred. Republishing message.'),
                 Argument::exact(array(
                     'swarrot_processor' => 'retry',
                     'exception' => $exception,
+                    'number_of_attempts' => 1,
+                    'key' => 'key_1',
                 ))
             )
             ->shouldBeCalledTimes(1)
@@ -494,10 +498,12 @@ class RetryProcessorTest extends TestCase
         $logger
             ->log(
                 Argument::exact(LogLevel::CRITICAL),
-                Argument::exact('[Retry] An exception occurred. Republish message for the 1 times (key: key_1)'),
+                Argument::exact('[Retry] An exception occurred. Republishing message.'),
                 Argument::exact(array(
                     'swarrot_processor' => 'retry',
                     'exception' => $exception,
+                    'number_of_attempts' => 1,
+                    'key' => 'key_1',
                 ))
             )
             ->shouldBeCalledTimes(1)
@@ -540,10 +546,11 @@ class RetryProcessorTest extends TestCase
         $logger
             ->log(
                 Argument::exact(LogLevel::WARNING),
-                Argument::exact('[Retry] Stop attempting to process message after 4 attempts'),
+                Argument::exact('[Retry] Stop attempting to process message.'),
                 Argument::exact(array(
                     'swarrot_processor' => 'retry',
                     'exception' => $exception,
+                    'number_of_attempts' => 4,
                 ))
             )
             ->shouldBeCalledTimes(1)
@@ -588,10 +595,11 @@ class RetryProcessorTest extends TestCase
         $logger
             ->log(
                 Argument::exact(LogLevel::CRITICAL),
-                Argument::exact('[Retry] Stop attempting to process message after 4 attempts'),
+                Argument::exact('[Retry] Stop attempting to process message.'),
                 Argument::exact(array(
                     'swarrot_processor' => 'retry',
                     'exception' => $exception,
+                    'number_of_attempts' => 4,
                 ))
             )
             ->shouldBeCalledTimes(1)
@@ -636,10 +644,11 @@ class RetryProcessorTest extends TestCase
         $logger
             ->log(
                 Argument::exact(LogLevel::CRITICAL),
-                Argument::exact('[Retry] Stop attempting to process message after 4 attempts'),
+                Argument::exact('[Retry] Stop attempting to process message.'),
                 Argument::exact(array(
                     'swarrot_processor' => 'retry',
                     'exception' => $exception,
+                    'number_of_attempts' => 4,
                 ))
             )
             ->shouldBeCalledTimes(1)


### PR DESCRIPTION
This plays better with logging systems: those will often group logs by
message, showing how many time similar events happened.

Fixes #187

Not using [placeholders](https://github.com/php-fig/fig-standards/blob/master/accepted/PSR-3-logger-interface.md#12-message) for now because I don't know how widely used they are, tell me if you want me to.

I fixed 2 out 18 occurrences for now, but I like early feedback.

EDIT: 18/18