### PR TITLE
Bump vendors

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -23,8 +23,8 @@ matrix:
         # Test against librabbitmq cutting-edge
         - { php: 7.2, env: LIBRABBITMQ_VERSION=master }
         # Test with lowest & beta dependencies
-        - { php: 7.2, env: COMPOSER_FLAGS='--prefer-lowest --prefer-stable' }
-        - { php: 7.2, env: DEPENDENCIES=beta }
+        - { php: 7.1, env: COMPOSER_FLAGS='--prefer-lowest --prefer-stable' }
+        - { php: 7.3, env: DEPENDENCIES=beta }
         # Other modes
         - { php: 7.2, env: MODE=syntax }
 

--- a/composer.json
+++ b/composer.json
@@ -12,28 +12,29 @@
     ],
     "require": {
         "php": "^7.1",
-        "symfony/options-resolver": "^2.8 || ^3.0 || ^4.0",
+        "symfony/options-resolver": "^3.4 || ^4.1",
         "psr/log": "^1.0"
     },
     "require-dev": {
-        "phpunit/phpunit": "^6.2",
+        "phpunit/phpunit": "^7.5",
         "php-amqplib/php-amqplib": "^2.1",
         "queue-interop/queue-interop": "^0.5",
         "queue-interop/amqp-interop": "^0.5",
         "doctrine/common": "^2.3",
         "doctrine/dbal": "^2.2",
         "aws/aws-sdk-php": "^2.8",
-        "sentry/sentry": ">=1.5.0",
-        "stomp-php/stomp-php": "^4.3.1"
+        "sentry/sentry": "^1.5",
+        "stomp-php/stomp-php": "^4.3.1",
+        "php-http/curl-client": "^2.0"
     },
     "suggest": {
         "pecl-amqp": "*",
         "php-amqplib/php-amqplib": "^2.1",
-        "symfony/console": "^3.0",
+        "symfony/console": "^3.4 || ^4.1",
         "queue-interop/queue-interop": "^0.5",
         "queue-interop/amqp-interop": "^0.5",
         "aws/aws-sdk-php": "^2.8",
-        "sentry/sentry": ">=1.5.0",
+        "sentry/sentry": "^1.5",
         "stomp-php/stomp-php": "^4.3.1"
     },
     "autoload": {

--- a/phpunit.xml.dist
+++ b/phpunit.xml.dist
@@ -8,7 +8,6 @@
     convertWarningsToExceptions="true"
     processIsolation="false"
     stopOnFailure="false"
-    syntaxCheck="false"
     bootstrap="vendor/autoload.php"
     >
 


### PR DESCRIPTION
No more symfony 2.x & limit some vendors (sentry & aws) as our code is not compatible with their latest versions.