### PR TITLE
Deprecate some processors & SQS message provider

### DIFF
--- a/src/Swarrot/Broker/MessageProvider/SqsMessageProvider.php
+++ b/src/Swarrot/Broker/MessageProvider/SqsMessageProvider.php
@@ -33,6 +33,8 @@ class SqsMessageProvider implements MessageProviderInterface
         $waitTime = 5,
         $requeueTimeout = 0
     ) {
+        @trigger_error(sprintf('"%s" have been deprecated since Swarrot 3.5', __CLASS__), E_USER_DEPRECATED);
+
         $this->channel = $channel;
         $this->queueName = $queueName;
         $this->cache = $cache ?: new PrefetchMessageCache();

--- a/src/Swarrot/Processor/RPC/RpcClientProcessor.php
+++ b/src/Swarrot/Processor/RPC/RpcClientProcessor.php
@@ -35,6 +35,8 @@ class RpcClientProcessor implements ProcessorInterface, ConfigurableInterface, S
 
     public function __construct(ProcessorInterface $processor = null, LoggerInterface $logger = null)
     {
+        @trigger_error(sprintf('"%s" have been deprecated since Swarrot 3.5', __CLASS__), E_USER_DEPRECATED);
+
         $this->processor = $processor;
         $this->logger = $logger ?: new NullLogger();
     }

--- a/src/Swarrot/Processor/RPC/RpcServerProcessor.php
+++ b/src/Swarrot/Processor/RPC/RpcServerProcessor.php
@@ -26,6 +26,8 @@ class RpcServerProcessor implements ProcessorInterface
 
     public function __construct(ProcessorInterface $processor, MessagePublisherInterface $publisher, LoggerInterface $logger = null)
     {
+        @trigger_error(sprintf('"%s" have been deprecated since Swarrot 3.5', __CLASS__), E_USER_DEPRECATED);
+
         $this->processor = $processor;
         $this->publisher = $publisher;
         $this->logger = $logger ?: new NullLogger();

--- a/src/Swarrot/Processor/Sentry/SentryProcessor.php
+++ b/src/Swarrot/Processor/Sentry/SentryProcessor.php
@@ -19,6 +19,8 @@ class SentryProcessor implements ProcessorInterface
 
     public function __construct(ProcessorInterface $processor, \Raven_Client $client)
     {
+        @trigger_error(sprintf('"%s" have been deprecated since Swarrot 3.5', __CLASS__), E_USER_DEPRECATED);
+
         $this->processor = $processor;
         $this->client = $client;
     }


### PR DESCRIPTION
In order to get rid of outdated dependencies (`aws/aws-sdk-php` & `sentry/sentry`) I'd like to deprecate some classes & remove them in 4.0.

@nicolasThal are you still using swarrot with the SQS message provider?
@notFloran are you still using the SentryProcessor?
@Taluu are you still using RPC processors?

Any concern @stof @lyrixx?
