### PR TITLE
Deprecate Stomp message providers

### DIFF
--- a/src/Swarrot/Broker/MessageProvider/SimpleStompMessageProvider.php
+++ b/src/Swarrot/Broker/MessageProvider/SimpleStompMessageProvider.php
@@ -39,6 +39,8 @@ class SimpleStompMessageProvider implements MessageProviderInterface
         $selector = null,
         array $header = []
     ) {
+        @trigger_error(sprintf('"%s" have been deprecated since Swarrot 3.6', __CLASS__), E_USER_DEPRECATED);
+
         $this->client = $client;
         $this->destination = $destination;
 

--- a/src/Swarrot/Broker/MessageProvider/StatefulStompMessageProvider.php
+++ b/src/Swarrot/Broker/MessageProvider/StatefulStompMessageProvider.php
@@ -36,6 +36,8 @@ class StatefulStompMessageProvider implements MessageProviderInterface
         $ack = 'client',
         array $header = []
     ) {
+        @trigger_error(sprintf('"%s" have been deprecated since Swarrot 3.6', __CLASS__), E_USER_DEPRECATED);
+
         $this->client = $client;
         $this->destination = $destination;
 


### PR DESCRIPTION
Hi @instabledesign 

In order to limit dependencies used by swarrot & improve maintainability, I consider deprecate some processors & providers (see #197 )

Do you still use swarrot & stomp providers?

Thanks!