### PR TITLE
Fix some type related errors

### DIFF
--- a/src/Swarrot/Broker/MessagePublisher/MessagePublisherInterface.php
+++ b/src/Swarrot/Broker/MessagePublisher/MessagePublisherInterface.php
@@ -12,7 +12,7 @@ interface MessagePublisherInterface
      * @param Message $message The message to publish
      * @param string  $key     A routing key to use
      */
-    public function publish(Message $message, $key = null);
+    public function publish(Message $message, $key = '');
 
     /**
      * getExchangeName.

--- a/src/Swarrot/Broker/MessagePublisher/SimpleStompMessagePublisher.php
+++ b/src/Swarrot/Broker/MessagePublisher/SimpleStompMessagePublisher.php
@@ -45,15 +45,15 @@ class SimpleStompMessagePublisher implements MessagePublisherInterface
     }
 
     /**
-     * @param null $key
+     * @param string $key
      */
-    public function publish(Message $message, $key = null)
+    public function publish(Message $message, $key = '')
     {
         $this->stomp->send($key, new StompMessage($message->getBody(), $message->getProperties()));
     }
 
     public function getExchangeName()
     {
-        return;
+        return '';
     }
 }

--- a/src/Swarrot/Processor/NewRelic/NewRelicProcessor.php
+++ b/src/Swarrot/Processor/NewRelic/NewRelicProcessor.php
@@ -45,7 +45,7 @@ class NewRelicProcessor implements ConfigurableInterface
             $result = $this->processor->process($message, $options);
         } catch (\Exception $e) {
             if ($this->extensionLoaded) {
-                newrelic_notice_error(null, $e);
+                newrelic_notice_error($e);
                 newrelic_end_transaction();
             }
 

--- a/src/Swarrot/Processor/XDeath/XDeathMaxLifetimeProcessor.php
+++ b/src/Swarrot/Processor/XDeath/XDeathMaxLifetimeProcessor.php
@@ -147,6 +147,8 @@ class XDeathMaxLifetimeProcessor implements ConfigurableInterface
     /**
      * @param \Exception|\Throwable $exception
      * @param string                $logMessage
+     *
+     * @return void
      */
     private function logException($exception, $logMessage, array $logLevelsMap)
     {


### PR DESCRIPTION
* the $key argument of publish() in MessagePublisherInterface should be
  a string
* getExchangeName() in SimpleStompMessagePublisher should return a
  string as per interface contract
* newrelic_notice_error takes a string or an exception as parameter, not
  null and then an exception. See
https://docs.newrelic.com/docs/agents/php-agent/php-agent-api/newrelic_notice_error