### PR TITLE
Fix newrelic_notice_error() call

### DIFF
--- a/src/Swarrot/Processor/NewRelic/NewRelicProcessor.php
+++ b/src/Swarrot/Processor/NewRelic/NewRelicProcessor.php
@@ -45,7 +45,7 @@ class NewRelicProcessor implements ConfigurableInterface
             $result = $this->processor->process($message, $options);
         } catch (\Exception $e) {
             if ($this->extensionLoaded) {
-                newrelic_notice_error(null, $e);
+                newrelic_notice_error($e);
                 newrelic_end_transaction();
             }
 


### PR DESCRIPTION
First argument should be a string or a Throwable|Exception. See:
https://docs.newrelic.com/docs/agents/php-agent/php-agent-api/newrelic_notice_error