### PR TITLE
Ensure all processors return a bool

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -41,10 +41,6 @@ matrix:
 
     allow_failures:
         - { php: 7.4, env: STABILITY=dev }
-        # Those PHP 7.4 tests fails due to outdated sentry dependency.
-        # To be removed once we'll get rid of sentry.
-        - { php: 7.4 }
-        - { php: 7.4, env: LIBRABBITMQ_VERSION=master }
 
 before_install:
   - if ! [ -z "$STABILITY" ]; then composer config minimum-stability ${STABILITY}; fi;

--- a/composer.json
+++ b/composer.json
@@ -25,7 +25,9 @@
         "aws/aws-sdk-php": "^2.8",
         "sentry/sentry": "^1.5",
         "stomp-php/stomp-php": "^4.3.1",
-        "php-http/curl-client": "^2.0"
+        "php-http/curl-client": "^2.0",
+        "symfony/phpunit-bridge": "^5.0",
+        "symfony/error-handler": "^5.0"
     },
     "suggest": {
         "pecl-amqp": "*",

--- a/composer.json
+++ b/composer.json
@@ -21,7 +21,7 @@
         "queue-interop/queue-interop": "^0.5",
         "queue-interop/amqp-interop": "^0.5",
         "doctrine/common": "^2.3",
-        "doctrine/dbal": "^2.2",
+        "doctrine/dbal": "^2.4",
         "aws/aws-sdk-php": "^2.8",
         "sentry/sentry": "^1.5",
         "stomp-php/stomp-php": "^4.3.1",

--- a/phpunit.xml.dist
+++ b/phpunit.xml.dist
@@ -11,17 +11,22 @@
     bootstrap="vendor/autoload.php"
     >
 
+    <listeners>
+        <listener class="Symfony\Bridge\PhpUnit\SymfonyTestsListener"/>
+    </listeners>
+
     <testsuites>
-        <testsuite name="Swarrot full test suite">
-            <directory>tests/</directory>
+        <testsuite name="Tests">
+            <directory>./tests</directory>
         </testsuite>
     </testsuites>
 
     <filter>
         <whitelist>
-            <directory>./</directory>
+            <directory suffix=".php">./</directory>
             <exclude>
-                <directory>./vendor</directory>
+                <directory>vendor</directory>
+                <directory>tests</directory>
             </exclude>
         </whitelist>
     </filter>

--- a/src/Swarrot/Processor/Ack/AckProcessor.php
+++ b/src/Swarrot/Processor/Ack/AckProcessor.php
@@ -62,6 +62,8 @@ class AckProcessor implements ConfigurableInterface
         } catch (\Exception $e) {
             $this->handleException($e, $message, $options);
         }
+
+        return true;
     }
 
     /**

--- a/src/Swarrot/Processor/ExceptionCatcher/ExceptionCatcherProcessor.php
+++ b/src/Swarrot/Processor/ExceptionCatcher/ExceptionCatcherProcessor.php
@@ -38,7 +38,7 @@ class ExceptionCatcherProcessor implements ProcessorInterface
             $this->handleException($e, $message, $options);
         }
 
-        return;
+        return true;
     }
 
     /**

--- a/src/Swarrot/Processor/ProcessorInterface.php
+++ b/src/Swarrot/Processor/ProcessorInterface.php
@@ -13,7 +13,7 @@ interface ProcessorInterface
      * @param Message $message The message given by a MessageProvider
      * @param array   $options An array containing all parameters
      *
-     * @return bool|null
+     * @return bool
      */
     public function process(Message $message, array $options);
 }

--- a/src/Swarrot/Processor/Retry/RetryProcessor.php
+++ b/src/Swarrot/Processor/Retry/RetryProcessor.php
@@ -37,6 +37,8 @@ class RetryProcessor implements ConfigurableInterface
         } catch (\Exception $e) {
             $this->handleException($e, $message, $options);
         }
+
+        return true;
     }
 
     /**

--- a/tests/Swarrot/Broker/MessageProvider/SimpleStompMessageProviderTest.php
+++ b/tests/Swarrot/Broker/MessageProvider/SimpleStompMessageProviderTest.php
@@ -63,6 +63,10 @@ class SimpleStompMessageProviderTest extends TestCase
         );
     }
 
+    /**
+     * @group legacy
+     * @expectedDeprecation "Swarrot\Broker\MessageProvider\SimpleStompMessageProvider" have been deprecated since Swarrot 3.6
+     */
     public function test_get_with_messages_in_queue_return_message()
     {
         $frame = $this->prophesize(Frame::class);
@@ -85,6 +89,10 @@ class SimpleStompMessageProviderTest extends TestCase
         $this->assertInstanceOf('Swarrot\Broker\Message', $message);
     }
 
+    /**
+     * @group legacy
+     * @expectedDeprecation "Swarrot\Broker\MessageProvider\SimpleStompMessageProvider" have been deprecated since Swarrot 3.6
+     */
     public function test_get_without_messages_in_queue_return_null()
     {
         $this->client
@@ -97,6 +105,10 @@ class SimpleStompMessageProviderTest extends TestCase
         $this->assertNull($message);
     }
 
+    /**
+     * @group legacy
+     * @expectedDeprecation "Swarrot\Broker\MessageProvider\SimpleStompMessageProvider" have been deprecated since Swarrot 3.6
+     */
     public function test_ack()
     {
         $frame = $this->prophesize(Frame::class);
@@ -118,6 +130,10 @@ class SimpleStompMessageProviderTest extends TestCase
         $this->provider->ack(new Message('fake_body', ['fake_property']));
     }
 
+    /**
+     * @group legacy
+     * @expectedDeprecation "Swarrot\Broker\MessageProvider\SimpleStompMessageProvider" have been deprecated since Swarrot 3.6
+     */
     public function test_nack()
     {
         $frame = $this->prophesize(Frame::class);
@@ -143,6 +159,10 @@ class SimpleStompMessageProviderTest extends TestCase
         $this->provider->nack(new Message('fake_body', ['fake_property']), true);
     }
 
+    /**
+     * @group legacy
+     * @expectedDeprecation "Swarrot\Broker\MessageProvider\SimpleStompMessageProvider" have been deprecated since Swarrot 3.6
+     */
     public function test_nack_without_protocol()
     {
         $this->client
@@ -156,6 +176,10 @@ class SimpleStompMessageProviderTest extends TestCase
         $this->provider->nack(new Message('fake_body', ['fake_property']), true);
     }
 
+    /**
+     * @group legacy
+     * @expectedDeprecation "Swarrot\Broker\MessageProvider\SimpleStompMessageProvider" have been deprecated since Swarrot 3.6
+     */
     public function test_get_name()
     {
         $this->assertEquals('fake_destination', $this->provider->getQueueName());

--- a/tests/Swarrot/Broker/MessageProvider/SqsMessageProviderTest.php
+++ b/tests/Swarrot/Broker/MessageProvider/SqsMessageProviderTest.php
@@ -26,7 +26,8 @@ class SqsMessageProviderTest extends TestCase
     protected $cache;
 
     /**
-     * Set up the test.
+     * @group legacy
+     * @expectedDeprecation "Swarrot\Broker\MessageProvider\SqsMessageProvider" have been deprecated since Swarrot 3.5
      */
     public function setUp(): void
     {
@@ -37,7 +38,8 @@ class SqsMessageProviderTest extends TestCase
     }
 
     /**
-     * Test instance.
+     * @group legacy
+     * @expectedDeprecation "Swarrot\Broker\MessageProvider\SqsMessageProvider" have been deprecated since Swarrot 3.5
      */
     public function testInstance()
     {
@@ -45,7 +47,8 @@ class SqsMessageProviderTest extends TestCase
     }
 
     /**
-     * Test with no cache.
+     * @group legacy
+     * @expectedDeprecation "Swarrot\Broker\MessageProvider\SqsMessageProvider" have been deprecated since Swarrot 3.5
      */
     public function testGetWithNoCache()
     {
@@ -72,7 +75,8 @@ class SqsMessageProviderTest extends TestCase
     }
 
     /**
-     * Test with no cache.
+     * @group legacy
+     * @expectedDeprecation "Swarrot\Broker\MessageProvider\SqsMessageProvider" have been deprecated since Swarrot 3.5
      */
     public function testGetWithNoResult()
     {
@@ -92,7 +96,8 @@ class SqsMessageProviderTest extends TestCase
     }
 
     /**
-     * Test with cache.
+     * @group legacy
+     * @expectedDeprecation "Swarrot\Broker\MessageProvider\SqsMessageProvider" have been deprecated since Swarrot 3.5
      */
     public function testGetWithCache()
     {
@@ -107,6 +112,10 @@ class SqsMessageProviderTest extends TestCase
         $this->channel->receiveMessage(Argument::any())->shouldNotBeCalled();
     }
 
+    /**
+     * @group legacy
+     * @expectedDeprecation "Swarrot\Broker\MessageProvider\SqsMessageProvider" have been deprecated since Swarrot 3.5
+     */
     public function testAck()
     {
         $message = $this->prophesize(Message::class);
@@ -120,6 +129,10 @@ class SqsMessageProviderTest extends TestCase
         $this->provider->ack($message->reveal());
     }
 
+    /**
+     * @group legacy
+     * @expectedDeprecation "Swarrot\Broker\MessageProvider\SqsMessageProvider" have been deprecated since Swarrot 3.5
+     */
     public function testNackWithRequeue()
     {
         $message = $this->prophesize(Message::class);
@@ -135,6 +148,10 @@ class SqsMessageProviderTest extends TestCase
         $this->provider->nack($message->reveal(), true);
     }
 
+    /**
+     * @group legacy
+     * @expectedDeprecation "Swarrot\Broker\MessageProvider\SqsMessageProvider" have been deprecated since Swarrot 3.5
+     */
     public function testNackWithoutRequeue()
     {
         $message = $this->prophesize(Message::class);

--- a/tests/Swarrot/Broker/MessageProvider/StatefulStompMessageProviderTest.php
+++ b/tests/Swarrot/Broker/MessageProvider/StatefulStompMessageProviderTest.php
@@ -60,6 +60,10 @@ class StatefulStompMessageProviderTest extends TestCase
         );
     }
 
+    /**
+     * @group legacy
+     * @expectedDeprecation "Swarrot\Broker\MessageProvider\StatefulStompMessageProvider" have been deprecated since Swarrot 3.6
+     */
     public function test_get_with_messages_in_queue_return_message()
     {
         $frame = $this->prophesize(Frame::class);
@@ -82,6 +86,10 @@ class StatefulStompMessageProviderTest extends TestCase
         $this->assertInstanceOf('Swarrot\Broker\Message', $message);
     }
 
+    /**
+     * @group legacy
+     * @expectedDeprecation "Swarrot\Broker\MessageProvider\StatefulStompMessageProvider" have been deprecated since Swarrot 3.6
+     */
     public function test_get_without_messages_in_queue_return_null()
     {
         $this->client
@@ -94,6 +102,10 @@ class StatefulStompMessageProviderTest extends TestCase
         $this->assertNull($message);
     }
 
+    /**
+     * @group legacy
+     * @expectedDeprecation "Swarrot\Broker\MessageProvider\StatefulStompMessageProvider" have been deprecated since Swarrot 3.6
+     */
     public function test_ack()
     {
         $frame = $this->prophesize(Frame::class);
@@ -115,6 +127,10 @@ class StatefulStompMessageProviderTest extends TestCase
         $this->provider->ack(new Message('fake_body', ['fake_property']));
     }
 
+    /**
+     * @group legacy
+     * @expectedDeprecation "Swarrot\Broker\MessageProvider\StatefulStompMessageProvider" have been deprecated since Swarrot 3.6
+     */
     public function test_nack()
     {
         $frame = $this->prophesize(Frame::class);
@@ -140,6 +156,10 @@ class StatefulStompMessageProviderTest extends TestCase
         $this->provider->nack(new Message('fake_body', ['fake_property']), true);
     }
 
+    /**
+     * @group legacy
+     * @expectedDeprecation "Swarrot\Broker\MessageProvider\StatefulStompMessageProvider" have been deprecated since Swarrot 3.6
+     */
     public function test_get_name()
     {
         $this->assertEquals('fake_destination', $this->provider->getQueueName());

--- a/tests/Swarrot/ConsumerTest.php
+++ b/tests/Swarrot/ConsumerTest.php
@@ -27,103 +27,109 @@ class ConsumerTest extends TestCase
 
     public function test_it_returns_null_if_no_error_occurred()
     {
-        $provider = $this->prophesize(MessageProviderInterface::class);
-        $processor = $this->prophesize(ProcessorInterface::class);
-
         $message = new Message('body', [], 1);
 
-        $provider->get()->willReturn($message);
-        $provider->getQueueName()->willReturn('image_crop');
+        $provider = $this->prophesize(MessageProviderInterface::class);
+        $provider->get()->shouldBeCalledTimes(1)->willReturn($message);
+        $provider->getQueueName()->shouldBeCalledTimes(1)->willReturn('my_queue');
+
+        $processor = $this->prophesize(ProcessorInterface::class);
         $processor
             ->process(
                 $message,
                 [
                     'poll_interval' => '50000',
-                    'queue' => 'image_crop',
+                    'queue' => 'my_queue',
                 ]
             )
+            ->shouldBeCalledTimes(1)
             ->willReturn(false)
         ;
 
         $consumer = new Consumer($provider->reveal(), $processor->reveal());
-        $this->assertNull($consumer->consume());
+        $consumer->consume();
     }
 
     public function test_it_call_processor_if_its_configurable()
     {
-        $provider = $this->prophesize(MessageProviderInterface::class);
-        $processor = $this->prophesize(ConfigurableInterface::class);
-
         $message = new Message('body', [], 1);
 
-        $provider->get()->willReturn($message);
-        $provider->getQueueName()->willReturn('');
-        $processor->setDefaultOptions(
-            Argument::type(OptionsResolver::class)
-        )->willReturn(null);
-        $processor->process(
-            $message,
-            Argument::type('array')
-        )->willReturn(false);
+        $provider = $this->prophesize(MessageProviderInterface::class);
+        $provider->get()->shouldBeCalledTimes(1)->willReturn($message);
+        $provider->getQueueName()->shouldBeCalledTimes(1)->willReturn('');
+
+        $processor = $this->prophesize(ConfigurableInterface::class);
+        $processor->setDefaultOptions(Argument::type(OptionsResolver::class))->shouldBeCalledTimes(1);
+        $processor->process($message, Argument::type('array'))->shouldBeCalledTimes(1)->willReturn(false);
 
         $consumer = new Consumer($provider->reveal(), $processor->reveal());
-        $this->assertNull($consumer->consume());
+        $consumer->consume();
     }
 
     public function test_it_call_processor_if_its_initializable()
     {
-        $provider = $this->prophesize(MessageProviderInterface::class);
-        $processor = $this->prophesize(InitializableInterface::class);
-
         $message = new Message('body', [], 1);
 
-        $provider->get()->willReturn($message);
-        $provider->getQueueName()->willReturn('');
-        $processor->initialize(Argument::type('array'))->willReturn(null);
-        $processor->process(
-            $message,
-            Argument::type('array')
-        )->willReturn(false);
+        $provider = $this->prophesize(MessageProviderInterface::class);
+        $provider->get()->shouldBeCalledTimes(1)->willReturn($message);
+        $provider->getQueueName()->shouldBeCalledTimes(1)->willReturn('');
+
+        $processor = $this->prophesize(InitializableInterface::class);
+        $processor->initialize(Argument::type('array'))->shouldBeCalledTimes(1);
+        $processor->process($message, Argument::type('array'))->shouldBeCalledTimes(1)->willReturn(false);
 
         $consumer = new Consumer($provider->reveal(), $processor->reveal());
-        $this->assertNull($consumer->consume());
+        $consumer->consume();
     }
 
     public function test_it_call_processor_if_its_terminable()
     {
-        $provider = $this->prophesize(MessageProviderInterface::class);
-        $processor = $this->prophesize(TerminableInterface::class);
-
         $message = new Message('body', [], 1);
 
-        $provider->get()->willReturn($message);
-        $provider->getQueueName()->willReturn('');
+        $provider = $this->prophesize(MessageProviderInterface::class);
+        $provider->get()->shouldBeCalledTimes(1)->willReturn($message);
+        $provider->getQueueName()->shouldBeCalledTimes(1)->willReturn('');
+
+        $processor = $this->prophesize(TerminableInterface::class);
         $processor->terminate(Argument::type('array'))->willReturn(null);
-        $processor->process(
-            $message,
-            Argument::type('array')
-        )->willReturn(false);
+        $processor->process($message, Argument::type('array'))->shouldBeCalledTimes(1)->willReturn(false);
 
         $consumer = new Consumer($provider->reveal(), $processor->reveal());
-        $this->assertNull($consumer->consume());
+        $consumer->consume();
     }
 
     public function test_it_call_processor_if_its_Sleepy()
     {
-        $provider = $this->prophesize(MessageProviderInterface::class);
-        $processor = $this->prophesize(SleepyInterface::class);
-
         $message = new Message('body', [], 1);
 
-        $provider->get()->willReturn($message);
-        $provider->getQueueName()->willReturn('');
+        $provider = $this->prophesize(MessageProviderInterface::class);
+        $provider->get()->shouldBeCalledTimes(1)->willReturn($message);
+        $provider->getQueueName()->shouldBeCalledTimes(1)->willReturn('');
+
+        $processor = $this->prophesize(SleepyInterface::class);
         $processor->sleep(Argument::type('array'))->willReturn(null);
-        $processor->process(
-            $message,
-            Argument::type('array')
-        )->willReturn(false);
+        $processor->process($message, Argument::type('array'))->shouldBeCalledTimes(1)->willReturn(false);
 
         $consumer = new Consumer($provider->reveal(), $processor->reveal());
-        $this->assertNull($consumer->consume());
+        $consumer->consume();
+    }
+
+    /**
+     * @group legacy
+     * @expectedDeprecation Processors must return a bool since Swarrot 3.7
+     */
+    public function test_it_triggers_a_deprecation_when_processor_return_null()
+    {
+        $message = new Message('body', [], 1);
+
+        $provider = $this->prophesize(MessageProviderInterface::class);
+        $provider->get()->shouldBeCalledTimes(2)->willReturn($message);
+        $provider->getQueueName()->shouldBeCalledTimes(1)->willReturn('');
+
+        $processor = $this->prophesize(ProcessorInterface::class);
+        $processor->process($message, Argument::type('array'))->shouldBeCalledTimes(2)->willReturn(null, false);
+
+        $consumer = new Consumer($provider->reveal(), $processor->reveal());
+        $consumer->consume();
     }
 }

--- a/tests/Swarrot/Processor/ExceptionCatcher/ExceptionCatcherTest.php
+++ b/tests/Swarrot/Processor/ExceptionCatcher/ExceptionCatcherTest.php
@@ -30,12 +30,15 @@ class ExceptionCatcherTest extends TestCase
 
     public function test_it_should_return_void_when_no_exception_is_thrown()
     {
+        $message = new Message('body', [], 1);
+
         $processor = $this->prophesize(ProcessorInterface::class);
+        $processor->process($message, [])->shouldBeCalledTimes(1)->willReturn(true);
+
         $logger = $this->prophesize(LoggerInterface::class);
 
-        $message = new Message('body', [], 1);
         $processor = new ExceptionCatcherProcessor($processor->reveal(), $logger->reveal());
-        $this->assertNull($processor->process($message, []));
+        $this->assertTrue($processor->process($message, []));
     }
 
     public function test_it_should_throw_an_exception_after_consecutive_failed()
@@ -53,6 +56,6 @@ class ExceptionCatcherTest extends TestCase
 
         $processor = new ExceptionCatcherProcessor($processor->reveal(), $logger->reveal());
 
-        $this->assertNull($processor->process($message, []));
+        $this->assertTrue($processor->process($message, []));
     }
 }

--- a/tests/Swarrot/Processor/RPC/RpcClientProcessorTest.php
+++ b/tests/Swarrot/Processor/RPC/RpcClientProcessorTest.php
@@ -10,12 +10,20 @@ use Swarrot\Processor\RPC\RpcClientProcessor;
 
 class RpcClientProcessorTest extends TestCase
 {
+    /**
+     * @group legacy
+     * @expectedDeprecation "Swarrot\Processor\RPC\RpcClientProcessor" have been deprecated since Swarrot 3.5
+     */
     public function test_it_is_initializable_without_a_logger()
     {
         $processor = new RpcClientProcessor();
         $this->assertInstanceOf(RpcClientProcessor::class, $processor);
     }
 
+    /**
+     * @group legacy
+     * @expectedDeprecation "Swarrot\Processor\RPC\RpcClientProcessor" have been deprecated since Swarrot 3.5
+     */
     public function test_it_is_initializable_with_a_logger()
     {
         $logger = $this->prophesize(LoggerInterface::class);
@@ -24,6 +32,10 @@ class RpcClientProcessorTest extends TestCase
         $this->assertInstanceOf(RpcClientProcessor::class, $processor);
     }
 
+    /**
+     * @group legacy
+     * @expectedDeprecation "Swarrot\Processor\RPC\RpcClientProcessor" have been deprecated since Swarrot 3.5
+     */
     public function test_it_is_initializable_with_a_processor()
     {
         $processor = $this->prophesize(ProcessorInterface::class);
@@ -32,6 +44,10 @@ class RpcClientProcessorTest extends TestCase
         $this->assertInstanceOf(RpcClientProcessor::class, $processor);
     }
 
+    /**
+     * @group legacy
+     * @expectedDeprecation "Swarrot\Processor\RPC\RpcClientProcessor" have been deprecated since Swarrot 3.5
+     */
     public function test_it_is_initializable_with_a_processor_and_a_logger()
     {
         $processor = $this->prophesize(ProcessorInterface::class);
@@ -41,12 +57,20 @@ class RpcClientProcessorTest extends TestCase
         $this->assertInstanceOf(RpcClientProcessor::class, $processor);
     }
 
+    /**
+     * @group legacy
+     * @expectedDeprecation "Swarrot\Processor\RPC\RpcClientProcessor" have been deprecated since Swarrot 3.5
+     */
     public function test_it_should_sleep_if_no_correlation_id_set()
     {
         $processor = new RpcClientProcessor();
         $this->assertNull($processor->process(new Message(), []));
     }
 
+    /**
+     * @group legacy
+     * @expectedDeprecation "Swarrot\Processor\RPC\RpcClientProcessor" have been deprecated since Swarrot 3.5
+     */
     public function test_it_should_sleep_if_invalid_correlation_id()
     {
         $processor = new RpcClientProcessor();
@@ -56,6 +80,10 @@ class RpcClientProcessorTest extends TestCase
         $this->assertTrue($processor->sleep([]));
     }
 
+    /**
+     * @group legacy
+     * @expectedDeprecation "Swarrot\Processor\RPC\RpcClientProcessor" have been deprecated since Swarrot 3.5
+     */
     public function test_it_should_stop_if_correct_correlation_id()
     {
         $processor = new RpcClientProcessor();
@@ -65,6 +93,10 @@ class RpcClientProcessorTest extends TestCase
         $this->assertFalse($processor->sleep([]));
     }
 
+    /**
+     * @group legacy
+     * @expectedDeprecation "Swarrot\Processor\RPC\RpcClientProcessor" have been deprecated since Swarrot 3.5
+     */
     public function test_it_should_let_the_nested_processor_act_and_stop_if_correct_correlation_id()
     {
         $message = new Message(null, ['correlation_id' => 1]);

--- a/tests/Swarrot/Processor/RPC/RpcServerProcessorTest.php
+++ b/tests/Swarrot/Processor/RPC/RpcServerProcessorTest.php
@@ -12,6 +12,10 @@ use Swarrot\Processor\RPC\RpcServerProcessor;
 
 class RpcServerProcessorTest extends TestCase
 {
+    /**
+     * @group legacy
+     * @expectedDeprecation "Swarrot\Processor\RPC\RpcServerProcessor" have been deprecated since Swarrot 3.5
+     */
     public function test_it_is_initializable_without_a_logger()
     {
         $processor = $this->prophesize(ProcessorInterface::class);
@@ -21,6 +25,10 @@ class RpcServerProcessorTest extends TestCase
         $this->assertInstanceOf(RpcServerProcessor::class, $processor);
     }
 
+    /**
+     * @group legacy
+     * @expectedDeprecation "Swarrot\Processor\RPC\RpcServerProcessor" have been deprecated since Swarrot 3.5
+     */
     public function test_it_is_initializable_with_a_logger()
     {
         $processor = $this->prophesize(ProcessorInterface::class);
@@ -31,7 +39,12 @@ class RpcServerProcessorTest extends TestCase
         $this->assertInstanceOf(RpcServerProcessor::class, $processor);
     }
 
-    /** @dataProvider noPropertiesProvider */
+    /**
+     * @group legacy
+     * @expectedDeprecation "Swarrot\Processor\RPC\RpcServerProcessor" have been deprecated since Swarrot 3.5
+     *
+     * @dataProvider noPropertiesProvider
+     */
     public function test_it_should_do_an_early_return_if_no_adequate_properties(array $properties)
     {
         $processor = $this->prophesize(ProcessorInterface::class);
@@ -54,6 +67,10 @@ class RpcServerProcessorTest extends TestCase
                 [['reply_to' => 'foo', 'correlation_id' => 0]], ];
     }
 
+    /**
+     * @group legacy
+     * @expectedDeprecation "Swarrot\Processor\RPC\RpcServerProcessor" have been deprecated since Swarrot 3.5
+     */
     public function test_it_should_publish_a_new_message_when_done()
     {
         $message = new Message('', ['reply_to' => 'foo', 'correlation_id' => 42]);

--- a/tests/Swarrot/Processor/Retry/RetryProcessorTest.php
+++ b/tests/Swarrot/Processor/Retry/RetryProcessorTest.php
@@ -36,20 +36,18 @@ class RetryProcessorTest extends TestCase
 
     public function test_it_should_return_result_when_all_is_right()
     {
-        $processor = $this->prophesize(ProcessorInterface::class);
-        $messagePublisher = $this->prophesize(MessagePublisherInterface::class);
-        $logger = $this->prophesize(LoggerInterface::class);
-
         $message = new Message('body', [], 1);
 
-        $processor->process(Argument::exact($message), Argument::exact([]))->willReturn(null);
-        $messagePublisher
-            ->publish(Argument::exact($message))
-            ->shouldNotBeCalled(null)
-        ;
+        $processor = $this->prophesize(ProcessorInterface::class);
+        $processor->process($message, [])->shouldBeCalledTimes(1)->willReturn(true);
+
+        $messagePublisher = $this->prophesize(MessagePublisherInterface::class);
+        $messagePublisher->publish($message)->shouldNotBeCalled();
+
+        $logger = $this->prophesize(LoggerInterface::class);
 
         $processor = new RetryProcessor($processor->reveal(), $messagePublisher->reveal(), $logger->reveal());
-        $this->assertNull($processor->process($message, []));
+        $this->assertTrue($processor->process($message, []));
     }
 
     public function test_it_should_republished_message_when_an_exception_occurred()
@@ -88,7 +86,7 @@ class RetryProcessorTest extends TestCase
             ->shouldBeCalledTimes(1)
         ;
 
-        $this->assertNull(
+        $this->assertTrue(
             $retryProcessor->process($message, $options)
         );
     }
@@ -134,7 +132,7 @@ class RetryProcessorTest extends TestCase
             ->shouldBeCalledTimes(1)
         ;
 
-        $this->assertNull(
+        $this->assertTrue(
             $retryProcessor->process($message, $options)
         );
     }
@@ -183,7 +181,7 @@ class RetryProcessorTest extends TestCase
             ->shouldBeCalledTimes(1)
         ;
 
-        $this->assertNull(
+        $this->assertTrue(
             $retryProcessor->process($message, $options)
         );
     }
@@ -312,7 +310,7 @@ class RetryProcessorTest extends TestCase
             ->shouldBeCalledTimes(1)
         ;
 
-        $this->assertNull(
+        $this->assertTrue(
             $retryProcessor->process($message, $options)
         );
     }
@@ -361,7 +359,7 @@ class RetryProcessorTest extends TestCase
             ->shouldBeCalledTimes(1)
         ;
 
-        $this->assertNull(
+        $this->assertTrue(
             $retryProcessor->process($message, $options)
         );
     }
@@ -409,7 +407,7 @@ class RetryProcessorTest extends TestCase
             ->shouldBeCalledTimes(1)
         ;
 
-        $this->assertNull(
+        $this->assertTrue(
             $retryProcessor->process($message, $options)
         );
     }
@@ -459,7 +457,7 @@ class RetryProcessorTest extends TestCase
             ->shouldBeCalledTimes(1)
         ;
 
-        $this->assertNull(
+        $this->assertTrue(
             $retryProcessor->process($message, $options)
         );
     }
@@ -509,7 +507,7 @@ class RetryProcessorTest extends TestCase
             ->shouldBeCalledTimes(1)
         ;
 
-        $this->assertNull(
+        $this->assertTrue(
             $retryProcessor->process($message, $options)
         );
     }

--- a/tests/Swarrot/Processor/Sentry/SentryProcessorTest.php
+++ b/tests/Swarrot/Processor/Sentry/SentryProcessorTest.php
@@ -11,6 +11,10 @@ use Swarrot\Processor\Sentry\SentryProcessor;
 
 class SentryProcessorTest extends TestCase
 {
+    /**
+     * @group legacy
+     * @expectedDeprecation "Swarrot\Processor\Sentry\SentryProcessor" have been deprecated since Swarrot 3.5
+     */
     public function test_it_should_return_void_when_no_exception_is_thrown()
     {
         $processor = $this->prophesize(ProcessorInterface::class);
@@ -24,6 +28,10 @@ class SentryProcessorTest extends TestCase
         $this->assertNull($processor->process($message, []));
     }
 
+    /**
+     * @group legacy
+     * @expectedDeprecation "Swarrot\Processor\Sentry\SentryProcessor" have been deprecated since Swarrot 3.5
+     */
     public function test_it_should_capture_when_an_exception_is_thrown()
     {
         $processor = $this->prophesize(ProcessorInterface::class);


### PR DESCRIPTION
Starting from 3.7, all processors will have to return a bool.
Goal: add strict type hinting in 4.0