### PR TITLE
Document possible redeliveries

### DIFF
--- a/src/Swarrot/Processor/MaxExecutionTime/README.md
+++ b/src/Swarrot/Processor/MaxExecutionTime/README.md
@@ -3,3 +3,6 @@
 MaxExecutionTimeProcessor is a [swarrot](https://github.com/swarrot/swarrot)
 processor.
 Its goal is to stop the consumer when the max execution time have been reached.
+That might result in redeliveries in some cases, for instance if you start
+processing a message before the maximum execution time, then the next message
+will be redelivered.


### PR DESCRIPTION
We have been observing lots of redeliveries in our production
environment, and the only way I found to reproduce them was to use
`sleep($max_execution_time + 1)` at the beginning of my business
processor.
Increasing the max execution time resulted in a greater gap between
redeliveries, which confirms the hypothesis that this processor is
responsible for that.

The red bar on the graph below is the deploy success event for our application.

![Screenshot_2021-01-08  SEARCH  Microservice Datadog](https://user-images.githubusercontent.com/657779/104027385-9bd98e00-51c7-11eb-8bd0-4d524cbd87b8.png)


I was quite concerned because redeliveries, because of [how they are documented](https://www.rabbitmq.com/reliability.html#consumer-side):

> In the event of network failure (or a node failure), messages can be redelivered, and consumers must be prepared to handle deliveries they have seen in the past. It is recommended that consumer implementation is designed to be idempotent rather than to explicitly perform deduplication.

I thought something was wrong with our infrastructure, and asked around on the enterprise Slack if redeliveries were a bad thing, and was told that they probably were.

I think they might be avoided by doing the following:

```diff
     public function process(Message $message, array $options): bool
     {
         if (true === $this->isTimeExceeded($options)) {
             return false;
         }
 
         return $this->processor->process($message, $options);
+
+        if (true === $this->isTimeExceeded($options)) {
+            return false;
+        }
     }
```

That would probably result in the current message not being ack'ed right?