### PR TITLE
Check time after running the child processor

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -2,3 +2,4 @@
 /bin
 /composer.lock
 /.php_cs.cache
+/.phpunit.result.cache

--- a/src/Swarrot/Processor/MaxExecutionTime/MaxExecutionTimeProcessor.php
+++ b/src/Swarrot/Processor/MaxExecutionTime/MaxExecutionTimeProcessor.php
@@ -61,11 +61,7 @@ class MaxExecutionTimeProcessor implements ConfigurableInterface, InitializableI
      */
     public function process(Message $message, array $options): bool
     {
-        if (true === $this->isTimeExceeded($options)) {
-            return false;
-        }
-
-        return $this->processor->process($message, $options);
+        return $this->processor->process($message, $options) && !$this->isTimeExceeded($options);
     }
 
     protected function isTimeExceeded(array $options): bool


### PR DESCRIPTION
There are two checks in the processor: on in process(), one in sleep().
In the event there are many messages in the queue when the time limit is
reached, it will be the check in process() that will kick in. Most users
will put the AckProcessor inside this one because that is what is
recommended in the docs, and will there will be no ack or nack in that
case, because of that check, which means there will be redeliveries.
By performing the check after running the child processor, we avoid the
redeliveries.

Closes #227 