### PR TITLE
Update the branch alias

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -52,7 +52,7 @@
     },
     "extra": {
         "branch-alias": {
-            "dev-master": "4.12.x-dev"
+            "dev-main": "4.x-dev"
         }
     }
 }


### PR DESCRIPTION
This updates the branch alias to account for the renaming of master to main. It also updates the alias to avoid specifying a particular minor version, so that it does not need to be updated after each release (which had been forgotten)