### PR TITLE
Add a processor to reset the peak memory usage

### DIFF
--- a/src/Swarrot/Processor/MemoryReset/MemoryResetProcessor.php
+++ b/src/Swarrot/Processor/MemoryReset/MemoryResetProcessor.php
@@ -1,0 +1,27 @@
+<?php
+
+namespace Swarrot\Processor\MemoryReset;
+
+use Swarrot\Broker\Message;
+use Swarrot\Processor\ProcessorInterface;
+
+class MemoryResetProcessor implements ProcessorInterface
+{
+    private ProcessorInterface $processor;
+
+    public function __construct(ProcessorInterface $processor)
+    {
+        $this->processor = $processor;
+    }
+
+    public function process(Message $message, array $options): bool
+    {
+        $return = $this->processor->process($message, $options);
+
+        if (\PHP_VERSION_ID >= 80200) {
+            memory_reset_peak_usage();
+        }
+
+        return $return;
+    }
+}

--- a/src/Swarrot/Processor/MemoryReset/README.md
+++ b/src/Swarrot/Processor/MemoryReset/README.md
@@ -1,0 +1,6 @@
+# MemoryResetProcessor
+
+MemoryResetProcessor is a [swarrot](https://github.com/swarrot/swarrot) processor.
+The goal of this processor is to reset the peak memory usage after processing each message, to allow profiling tools
+distinguishing each message to report an accurate peak memory usage.
+As resetting the peak memory usage is supported only on PHP 8.2+, this processor is a no-op on older PHP versions.

--- a/tests/Swarrot/Processor/MemoryReset/MemoryResetProcessorTest.php
+++ b/tests/Swarrot/Processor/MemoryReset/MemoryResetProcessorTest.php
@@ -1,0 +1,34 @@
+<?php
+
+namespace Swarrot\Tests\Processor\MemoryReset;
+
+use PHPUnit\Framework\TestCase;
+use Prophecy\PhpUnit\ProphecyTrait;
+use Swarrot\Broker\Message;
+use Swarrot\Processor\MemoryReset\MemoryResetProcessor;
+use Swarrot\Processor\ProcessorInterface;
+
+class MemoryResetProcessorTest extends TestCase
+{
+    use ProphecyTrait;
+
+    public function test_it_is_initializable()
+    {
+        $processor = $this->prophesize(ProcessorInterface::class);
+
+        $processor = new MemoryResetProcessor($processor->reveal());
+        $this->assertInstanceOf(MemoryResetProcessor::class, $processor);
+    }
+
+    public function test_delegate_processing()
+    {
+        $message = new Message('body', [], 1);
+
+        $processor = $this->prophesize(ProcessorInterface::class);
+        $processor->process($message, [])->shouldBeCalledTimes(1)->willReturn(true);
+
+        $processor = new MemoryResetProcessor($processor->reveal());
+
+        $this->assertTrue($processor->process($message, []));
+    }
+}


### PR DESCRIPTION
This is useful when you have another processor that reports the peak memory usage and you want to distinguish it per message instead of depending on the history of previous messages as well.
For instance, I have a custom processor using the [tideways](https://tideways.com/) API to report profiles for the message processing.
The expected usage is that we would use this MemoryResetProcessor on the outside of the stack of processors, so that the peak memory usage is reset after it has been reported to Tideways (and also after the Doctrine EntityManager has been cleared for instance, to release memory).

To make it easier to write projects supporting multiple PHP versions, I made this processor a no-op on PHP 8.1 and older instead of making it unsupported.