### PR TITLE
Update CI setup

### DIFF
--- a/.github/workflows/static.yml
+++ b/.github/workflows/static.yml
@@ -6,11 +6,20 @@ jobs:
   php-cs-fixer:
     runs-on: ubuntu-latest
     steps:
-      - uses: actions/checkout@v3
-      - name: PHP-CS-Fixer
-        uses: docker://odolbeau/swarrot-phpqa:latest
+      - uses: actions/checkout@v4
+
+      - name: Setup PHP
+        uses: shivammathur/setup-php@v2
         with:
-            args: php-cs-fixer fix --dry-run --diff-format udiff -vvv
+          php-version: '8.2'
+          extensions: amqp
+          coverage: none
+
+      - name: Install dependencies
+        run: composer install --no-interaction --prefer-dist --no-progress
+
+      - name: PHP-CS-Fixer
+        run: vendor/bin/php-cs-fixer fix --dry-run -vvv
 
   phpstan:
     runs-on: ubuntu-latest

--- a/.github/workflows/static.yml
+++ b/.github/workflows/static.yml
@@ -24,8 +24,17 @@ jobs:
   phpstan:
     runs-on: ubuntu-latest
     steps:
-      - uses: actions/checkout@v3
-      - name: Run PHPStan
-        uses: docker://odolbeau/swarrot-phpqa:latest
+      - uses: actions/checkout@v4
+
+      - name: Setup PHP
+        uses: shivammathur/setup-php@v2
         with:
-          args: phpstan analyze
+          php-version: '8.2'
+          extensions: amqp
+          coverage: none
+
+      - name: Install dependencies
+        run: composer install --no-interaction --prefer-dist --no-progress
+
+      - name: PHP-CS-Fixer
+        run: vendor/bin/phpstan analyze

--- a/.gitignore
+++ b/.gitignore
@@ -1,5 +1,5 @@
 /vendor
 /bin
 /composer.lock
-/.php_cs.cache
+/.php-cs-fixer.cache
 /.phpunit.result.cache

--- a/.php-cs-fixer.php
+++ b/.php-cs-fixer.php
@@ -1,10 +1,12 @@
 <?php
 
-$config = PhpCsFixer\Config::create()
+$config = (new PhpCsFixer\Config())
     ->setRiskyAllowed(true)
     ->setRules([
         '@Symfony' => true,
         '@Symfony:risky' => true,
+        'php_unit_method_casing' => false,
+        'get_class_to_class_keyword' => false,
     ])
     ->setFinder(
         PhpCsFixer\Finder::create()

--- a/composer.json
+++ b/composer.json
@@ -22,9 +22,9 @@
         "phpspec/prophecy": "^1.15",
         "phpspec/prophecy-phpunit": "^2.0",
         "phpunit/phpunit": "^9.6",
-        "symfony/contracts": "^1.0 || ^2.0 || ^3.0",
         "symfony/error-handler": "^5.0 || ^6.0",
-        "symfony/phpunit-bridge": "^5.0 || ^6.0"
+        "symfony/phpunit-bridge": "^5.0 || ^6.0",
+        "symfony/service-contracts": "^1.0 || ^2.0 || ^3.0"
     },
     "suggest": {
         "pecl-amqp": "*",

--- a/composer.json
+++ b/composer.json
@@ -16,14 +16,15 @@
         "psr/log": "^1.0 || ^2.0 || ^3.0"
     },
     "require-dev": {
-        "phpunit/phpunit": "^8.4",
+        "phpunit/phpunit": "^9.6",
         "php-amqplib/php-amqplib": "^2.1 || ^3.0",
         "doctrine/common": "^2.9",
         "doctrine/dbal": "^2.4",
         "symfony/phpunit-bridge": "^5.0 || ^6.0",
         "symfony/error-handler": "^5.0 || ^6.0",
         "symfony/contracts": "^1.0 || ^2.0 || ^3.0",
-        "phpspec/prophecy": "^1.15"
+        "phpspec/prophecy": "^1.15",
+        "phpspec/prophecy-phpunit": "^2.0"
     },
     "suggest": {
         "pecl-amqp": "*",

--- a/composer.json
+++ b/composer.json
@@ -16,15 +16,15 @@
         "psr/log": "^1.0 || ^2.0 || ^3.0"
     },
     "require-dev": {
-        "phpunit/phpunit": "^9.6",
-        "php-amqplib/php-amqplib": "^2.1 || ^3.0",
         "doctrine/common": "^2.9",
         "doctrine/dbal": "^2.4",
-        "symfony/phpunit-bridge": "^5.0 || ^6.0",
-        "symfony/error-handler": "^5.0 || ^6.0",
-        "symfony/contracts": "^1.0 || ^2.0 || ^3.0",
+        "php-amqplib/php-amqplib": "^2.1 || ^3.0",
         "phpspec/prophecy": "^1.15",
-        "phpspec/prophecy-phpunit": "^2.0"
+        "phpspec/prophecy-phpunit": "^2.0",
+        "phpunit/phpunit": "^9.6",
+        "symfony/contracts": "^1.0 || ^2.0 || ^3.0",
+        "symfony/error-handler": "^5.0 || ^6.0",
+        "symfony/phpunit-bridge": "^5.0 || ^6.0"
     },
     "suggest": {
         "pecl-amqp": "*",
@@ -49,6 +49,9 @@
     },
     "conflict": {
         "doctrine/persistence": "<1.3"
+    },
+    "config": {
+        "sort-packages": true
     },
     "extra": {
         "branch-alias": {

--- a/composer.json
+++ b/composer.json
@@ -20,7 +20,6 @@
         "php-amqplib/php-amqplib": "^2.1 || ^3.0",
         "doctrine/common": "^2.9",
         "doctrine/dbal": "^2.4",
-        "php-http/curl-client": "^2.0",
         "symfony/phpunit-bridge": "^5.0 || ^6.0",
         "symfony/error-handler": "^5.0 || ^6.0",
         "symfony/contracts": "^1.0 || ^2.0 || ^3.0",

--- a/composer.json
+++ b/composer.json
@@ -22,6 +22,7 @@
         "php-amqplib/php-amqplib": "^2.1 || ^3.0",
         "phpspec/prophecy": "^1.15",
         "phpspec/prophecy-phpunit": "^2.0",
+        "phpstan/phpstan": "^1.10",
         "phpunit/phpunit": "^9.6",
         "symfony/error-handler": "^5.0 || ^6.0",
         "symfony/phpunit-bridge": "^5.0 || ^6.0",

--- a/composer.json
+++ b/composer.json
@@ -18,6 +18,7 @@
     "require-dev": {
         "doctrine/common": "^2.9",
         "doctrine/dbal": "^2.4",
+        "friendsofphp/php-cs-fixer": "^3.27",
         "php-amqplib/php-amqplib": "^2.1 || ^3.0",
         "phpspec/prophecy": "^1.15",
         "phpspec/prophecy-phpunit": "^2.0",

--- a/examples/03-x-death-count.php
+++ b/examples/03-x-death-count.php
@@ -58,11 +58,13 @@ $stack = (new \Swarrot\Processor\Stack\Builder())
         function ($e, $message, $options) {
             if (end($message->getProperties()['headers']['x-death'])['count'] > 5) {
                 printf("XDeathMaxCountProcessor callback executed. Not rethrow original exception\n");
+
                 // when you return false it not rethrow the catched exception
                 return false;
             }
 
             printf("XDeathMaxCountProcessor callback executed. Rethrow original exception\n");
+
             // when you return null it rethrow the catched exception
             return;
         },

--- a/phpstan.neon.dist
+++ b/phpstan.neon.dist
@@ -1,11 +1,9 @@
 parameters:
-    level: max
+    level: 8
     inferPrivatePropertyTypeFromConstructor: true
     checkMissingIterableValueType: false
     paths:
         - src
-    excludes_analyse:
-        - vendor
 
     ignoreErrors:
         -
@@ -19,14 +17,10 @@ parameters:
             path: src/Swarrot/Processor/Doctrine/ConnectionProcessor.php
 
         -
-            message: "#^Method Swarrot\\\\Broker\\\\MessagePublisher\\\\PeclPackageMessagePublisher\\:\\:__construct\\(\\) has parameter \\$timeout with no typehint specified\\.$#"
+            message: "#^Property Swarrot\\\\Processor\\\\Stack\\\\Builder\\:\\:\\$specs with generic class SplStack does not specify its types\\: TValue$#"
             count: 1
-            path: src/Swarrot/Broker/MessagePublisher/PeclPackageMessagePublisher.php
+            path: src/Swarrot/Processor/Stack/Builder.php
 
-        -
-            message: "#^Method Swarrot\\\\Broker\\\\MessagePublisher\\\\PhpAmqpLibMessagePublisher\\:\\:__construct\\(\\) has parameter \\$timeout with no typehint specified\\.$#"
-            count: 1
-            path: src/Swarrot/Broker/MessagePublisher/PhpAmqpLibMessagePublisher.php
         -
             message: "#^Parameter \\#1 \\$delivery_tag of method PhpAmqpLib\\\\Channel\\\\AMQPChannel\\:\\:basic_ack\\(\\) expects int, string given\\.$#"
             count: 1

--- a/phpunit.xml.dist
+++ b/phpunit.xml.dist
@@ -1,6 +1,7 @@
 <?xml version="1.0" encoding="UTF-8"?>
-
-<phpunit backupGlobals="false"
+<phpunit
+    xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
+    backupGlobals="false"
     backupStaticAttributes="false"
     colors="true"
     convertErrorsToExceptions="true"
@@ -9,7 +10,17 @@
     processIsolation="false"
     stopOnFailure="false"
     bootstrap="vendor/autoload.php"
-    >
+    xsi:noNamespaceSchemaLocation="vendor/phpunit/phpunit/phpunit.xsd"
+>
+    <coverage>
+        <include>
+            <directory suffix=".php">./</directory>
+        </include>
+        <exclude>
+            <directory>vendor</directory>
+            <directory>tests</directory>
+        </exclude>
+    </coverage>
 
     <listeners>
         <listener class="Symfony\Bridge\PhpUnit\SymfonyTestsListener"/>
@@ -24,15 +35,4 @@
             <directory>./tests</directory>
         </testsuite>
     </testsuites>
-
-    <filter>
-        <whitelist>
-            <directory suffix=".php">./</directory>
-            <exclude>
-                <directory>vendor</directory>
-                <directory>tests</directory>
-            </exclude>
-        </whitelist>
-    </filter>
-
 </phpunit>

--- a/src/Swarrot/Broker/MessageProvider/CallbackMessageProvider.php
+++ b/src/Swarrot/Broker/MessageProvider/CallbackMessageProvider.php
@@ -17,17 +17,11 @@ class CallbackMessageProvider implements MessageProviderInterface
         $this->nack = $nack;
     }
 
-    /**
-     * {@inheritdoc}
-     */
     public function get(): ?Message
     {
         return \call_user_func($this->get);
     }
 
-    /**
-     * {@inheritdoc}
-     */
     public function ack(Message $message): void
     {
         if (null === $this->ack) {
@@ -37,9 +31,6 @@ class CallbackMessageProvider implements MessageProviderInterface
         \call_user_func($this->ack, $message);
     }
 
-    /**
-     * {@inheritdoc}
-     */
     public function nack(Message $message, bool $requeue = false): void
     {
         if (null === $this->nack) {
@@ -49,9 +40,6 @@ class CallbackMessageProvider implements MessageProviderInterface
         \call_user_func($this->nack, $message, $requeue);
     }
 
-    /**
-     * {@inheritdoc}
-     */
     public function getQueueName(): string
     {
         return '';

--- a/src/Swarrot/Broker/MessageProvider/PeclPackageMessageProvider.php
+++ b/src/Swarrot/Broker/MessageProvider/PeclPackageMessageProvider.php
@@ -13,9 +13,6 @@ class PeclPackageMessageProvider implements MessageProviderInterface
         $this->queue = $queue;
     }
 
-    /**
-     * {@inheritdoc}
-     */
     public function get(): ?Message
     {
         $envelope = $this->queue->get();
@@ -52,9 +49,6 @@ class PeclPackageMessageProvider implements MessageProviderInterface
         );
     }
 
-    /**
-     * {@inheritdoc}
-     */
     public function ack(Message $message): void
     {
         if (null === $id = $message->getId()) {
@@ -64,21 +58,15 @@ class PeclPackageMessageProvider implements MessageProviderInterface
         $this->queue->ack($id);
     }
 
-    /**
-     * {@inheritdoc}
-     */
     public function nack(Message $message, bool $requeue = false): void
     {
         if (null === $id = $message->getId()) {
             throw new \RuntimeException('Cannot nack a message without id.');
         }
 
-        $this->queue->nack($id, $requeue ? AMQP_REQUEUE : 0);
+        $this->queue->nack($id, $requeue ? \AMQP_REQUEUE : 0);
     }
 
-    /**
-     * {@inheritdoc}
-     */
     public function getQueueName(): string
     {
         return $this->queue->getName();

--- a/src/Swarrot/Broker/MessageProvider/PhpAmqpLibMessageProvider.php
+++ b/src/Swarrot/Broker/MessageProvider/PhpAmqpLibMessageProvider.php
@@ -52,9 +52,6 @@ class PhpAmqpLibMessageProvider implements MessageProviderInterface
         return new Message($envelope->body, $properties, $envelope->get('delivery_tag'));
     }
 
-    /**
-     * {@inheritdoc}
-     */
     public function ack(Message $message): void
     {
         if (null === $id = $message->getId()) {
@@ -64,9 +61,6 @@ class PhpAmqpLibMessageProvider implements MessageProviderInterface
         $this->channel->basic_ack($id);
     }
 
-    /**
-     * {@inheritdoc}
-     */
     public function nack(Message $message, bool $requeue = false): void
     {
         if (null === $id = $message->getId()) {
@@ -76,9 +70,6 @@ class PhpAmqpLibMessageProvider implements MessageProviderInterface
         $this->channel->basic_nack($id, false, $requeue);
     }
 
-    /**
-     * {@inheritdoc}
-     */
     public function getQueueName(): string
     {
         return $this->queueName;

--- a/src/Swarrot/Broker/MessagePublisher/PeclPackageMessagePublisher.php
+++ b/src/Swarrot/Broker/MessagePublisher/PeclPackageMessagePublisher.php
@@ -21,7 +21,7 @@ class PeclPackageMessagePublisher implements MessagePublisherInterface
 
     public function __construct(
         \AMQPExchange $exchange,
-        int $flags = AMQP_NOPARAM,
+        int $flags = \AMQP_NOPARAM,
         LoggerInterface $logger = null,
         bool $publisherConfirms = false,
         $timeout = 0
@@ -40,9 +40,6 @@ class PeclPackageMessagePublisher implements MessagePublisherInterface
         }
     }
 
-    /**
-     * {@inheritdoc}
-     */
     public function publish(Message $message, string $key = null): void
     {
         $properties = $message->getProperties();
@@ -78,16 +75,13 @@ class PeclPackageMessagePublisher implements MessagePublisherInterface
             $this->sanitizeProperties($properties)
         );
         if ($this->publisherConfirms) {
-            //track published to see what needs to be acked
+            // track published to see what needs to be acked
             ++$this->lastDeliveryTag;
             $this->pendingMessages[$this->lastDeliveryTag] = $message;
             $this->exchange->getChannel()->waitForConfirm($this->timeout);
         }
     }
 
-    /**
-     * {@inheritdoc}
-     */
     public function getExchangeName(): string
     {
         return $this->exchange->getName();
@@ -96,7 +90,7 @@ class PeclPackageMessagePublisher implements MessagePublisherInterface
     private function getAckHandler(): callable
     {
         return function ($deliveryTag, $multiple) {
-            //remove acked from pending list
+            // remove acked from pending list
             if ($multiple) {
                 for ($tag = 0; $tag <= $multiple; ++$tag) {
                     unset($this->pendingMessages[$tag]);
@@ -106,7 +100,7 @@ class PeclPackageMessagePublisher implements MessagePublisherInterface
             }
 
             if (\count($this->pendingMessages) > 0) {
-                return true; //still need to wait
+                return true; // still need to wait
             }
 
             return false;

--- a/src/Swarrot/Broker/MessagePublisher/PeclPackageMessagePublisher.php
+++ b/src/Swarrot/Broker/MessagePublisher/PeclPackageMessagePublisher.php
@@ -19,6 +19,9 @@ class PeclPackageMessagePublisher implements MessagePublisherInterface
     /** @var array */
     private $pendingMessages = [];
 
+    /**
+     * @param int|float $timeout
+     */
     public function __construct(
         \AMQPExchange $exchange,
         int $flags = \AMQP_NOPARAM,

--- a/src/Swarrot/Broker/MessagePublisher/PhpAmqpLibMessagePublisher.php
+++ b/src/Swarrot/Broker/MessagePublisher/PhpAmqpLibMessagePublisher.php
@@ -8,10 +8,10 @@ use Swarrot\Broker\Message;
 
 class PhpAmqpLibMessagePublisher implements MessagePublisherInterface
 {
-    /** @var AMQPChannel $channel */
+    /** @var AMQPChannel */
     private $channel;
 
-    /** @var string $exchange Exchange's name. Required by php-amqplib */
+    /** @var string Exchange's name. Required by php-amqplib */
     private $exchange;
 
     /** @var int|float */
@@ -38,9 +38,6 @@ class PhpAmqpLibMessagePublisher implements MessagePublisherInterface
         $this->timeout = $timeout;
     }
 
-    /**
-     * {@inheritdoc}
-     */
     public function publish(Message $message, string $key = null): void
     {
         $properties = $message->getProperties();
@@ -69,9 +66,6 @@ class PhpAmqpLibMessagePublisher implements MessagePublisherInterface
         }
     }
 
-    /**
-     * {@inheritdoc}
-     */
     public function getExchangeName(): string
     {
         return $this->exchange;
@@ -80,7 +74,7 @@ class PhpAmqpLibMessagePublisher implements MessagePublisherInterface
     private function getNackHandler(): callable
     {
         return function (AMQPMessage $message) {
-            if ($message->has('delivery_tag') && is_scalar($message->get('delivery_tag'))) {
+            if ($message->has('delivery_tag') && \is_scalar($message->get('delivery_tag'))) {
                 throw new \Exception('Error publishing deliveryTag: '.$message->get('delivery_tag'));
             } else {
                 throw new \Exception('Error publishing message: '.$message->getBody());

--- a/src/Swarrot/Broker/MessagePublisher/PhpAmqpLibMessagePublisher.php
+++ b/src/Swarrot/Broker/MessagePublisher/PhpAmqpLibMessagePublisher.php
@@ -19,6 +19,9 @@ class PhpAmqpLibMessagePublisher implements MessagePublisherInterface
 
     private $publisherConfirms;
 
+    /**
+     * @param int|float $timeout
+     */
     public function __construct(
         AMQPChannel $channel,
         string $exchange,

--- a/src/Swarrot/Consumer.php
+++ b/src/Swarrot/Consumer.php
@@ -57,7 +57,7 @@ class Consumer
             while (null !== $message = $this->messageProvider->get()) {
                 $result = $this->processor->process($message, $options);
                 if (!\is_bool($result)) {
-                    @trigger_error('Processors must return a bool since Swarrot 3.7', E_USER_DEPRECATED);
+                    @trigger_error('Processors must return a bool since Swarrot 3.7', \E_USER_DEPRECATED);
                 }
                 if (false === $result) {
                     break 2;

--- a/src/Swarrot/Processor/Ack/AckProcessor.php
+++ b/src/Swarrot/Processor/Ack/AckProcessor.php
@@ -23,9 +23,6 @@ class AckProcessor implements ConfigurableInterface
         $this->logger = $logger ?: new NullLogger();
     }
 
-    /**
-     * {@inheritdoc}
-     */
     public function process(Message $message, array $options): bool
     {
         try {
@@ -61,9 +58,6 @@ class AckProcessor implements ConfigurableInterface
         }
     }
 
-    /**
-     * {@inheritdoc}
-     */
     public function setDefaultOptions(OptionsResolver $resolver): void
     {
         $resolver

--- a/src/Swarrot/Processor/Callback/CallbackProcessor.php
+++ b/src/Swarrot/Processor/Callback/CallbackProcessor.php
@@ -14,9 +14,6 @@ class CallbackProcessor implements ProcessorInterface
         $this->process = $process;
     }
 
-    /**
-     * {@inheritdoc}
-     */
     public function process(Message $message, array $options): bool
     {
         return \call_user_func($this->process, $message, $options);

--- a/src/Swarrot/Processor/Doctrine/ConnectionProcessor.php
+++ b/src/Swarrot/Processor/Doctrine/ConnectionProcessor.php
@@ -47,9 +47,6 @@ class ConnectionProcessor implements ConfigurableInterface
         $this->connections = $connections;
     }
 
-    /**
-     * {@inheritdoc}
-     */
     public function process(Message $message, array $options): bool
     {
         if ($options['doctrine_ping']) {
@@ -57,7 +54,7 @@ class ConnectionProcessor implements ConfigurableInterface
                 if ($connection->isConnected()) {
                     try {
                         $connection->query($connection->getDatabasePlatform()->getDummySelectSQL());
-                    } catch (DBAL2Exception | DBAL3Exception $e) {
+                    } catch (DBAL2Exception|DBAL3Exception $e) {
                         $connection->close(); // close timed out connections so that using them connects again
                     }
                 }
@@ -80,9 +77,6 @@ class ConnectionProcessor implements ConfigurableInterface
         }
     }
 
-    /**
-     * {@inheritdoc}
-     */
     public function setDefaultOptions(OptionsResolver $resolver): void
     {
         $resolver->setDefaults([

--- a/src/Swarrot/Processor/Doctrine/ObjectManagerProcessor.php
+++ b/src/Swarrot/Processor/Doctrine/ObjectManagerProcessor.php
@@ -20,9 +20,6 @@ class ObjectManagerProcessor implements ProcessorInterface
         $this->managerRegistry = $managerRegistry;
     }
 
-    /**
-     * {@inheritdoc}
-     */
     public function process(Message $message, array $options): bool
     {
         try {

--- a/src/Swarrot/Processor/ExceptionCatcher/ExceptionCatcherProcessor.php
+++ b/src/Swarrot/Processor/ExceptionCatcher/ExceptionCatcherProcessor.php
@@ -18,9 +18,6 @@ class ExceptionCatcherProcessor implements ProcessorInterface
         $this->logger = $logger ?: new NullLogger();
     }
 
-    /**
-     * {@inheritdoc}
-     */
     public function process(Message $message, array $options): bool
     {
         try {

--- a/src/Swarrot/Processor/Insomniac/InsomniacProcessor.php
+++ b/src/Swarrot/Processor/Insomniac/InsomniacProcessor.php
@@ -19,17 +19,11 @@ class InsomniacProcessor implements SleepyInterface
         $this->logger = $logger ?? new NullLogger();
     }
 
-    /**
-     * {@inheritdoc}
-     */
     public function process(Message $message, array $options): bool
     {
         return $this->processor->process($message, $options);
     }
 
-    /**
-     * {@inheritdoc}
-     */
     public function sleep(array $options): bool
     {
         // Since this should be called after the consumer was not able to retrieve a message,

--- a/src/Swarrot/Processor/InstantRetry/InstantRetryProcessor.php
+++ b/src/Swarrot/Processor/InstantRetry/InstantRetryProcessor.php
@@ -21,9 +21,6 @@ class InstantRetryProcessor implements ConfigurableInterface
         $this->logger = $logger ?: new NullLogger();
     }
 
-    /**
-     * {@inheritdoc}
-     */
     public function process(Message $message, array $options): bool
     {
         $retry = 0;
@@ -60,9 +57,6 @@ class InstantRetryProcessor implements ConfigurableInterface
         throw new \RuntimeException('You probably misconfigured the InstantRetryProcessor.');
     }
 
-    /**
-     * {@inheritdoc}
-     */
     public function setDefaultOptions(OptionsResolver $resolver): void
     {
         $resolver->setDefaults([

--- a/src/Swarrot/Processor/MaxExecutionTime/MaxExecutionTimeProcessor.php
+++ b/src/Swarrot/Processor/MaxExecutionTime/MaxExecutionTimeProcessor.php
@@ -27,9 +27,6 @@ class MaxExecutionTimeProcessor implements ConfigurableInterface, InitializableI
         $this->logger = $logger ?: new NullLogger();
     }
 
-    /**
-     * {@inheritdoc}
-     */
     public function setDefaultOptions(OptionsResolver $resolver): void
     {
         $resolver
@@ -40,25 +37,16 @@ class MaxExecutionTimeProcessor implements ConfigurableInterface, InitializableI
         ;
     }
 
-    /**
-     * {@inheritdoc}
-     */
     public function initialize(array $options): void
     {
         $this->startTime = microtime(true);
     }
 
-    /**
-     * {@inheritdoc}
-     */
     public function sleep(array $options): bool
     {
         return !$this->isTimeExceeded($options);
     }
 
-    /**
-     * {@inheritdoc}
-     */
     public function process(Message $message, array $options): bool
     {
         return $this->processor->process($message, $options) && !$this->isTimeExceeded($options);

--- a/src/Swarrot/Processor/MaxMessages/MaxMessagesProcessor.php
+++ b/src/Swarrot/Processor/MaxMessages/MaxMessagesProcessor.php
@@ -25,9 +25,6 @@ class MaxMessagesProcessor implements ConfigurableInterface
         $this->logger = $logger ?: new NullLogger();
     }
 
-    /**
-     * {@inheritdoc}
-     */
     public function process(Message $message, array $options): bool
     {
         $return = $this->processor->process($message, $options);
@@ -47,9 +44,6 @@ class MaxMessagesProcessor implements ConfigurableInterface
         return $return;
     }
 
-    /**
-     * {@inheritdoc}
-     */
     public function setDefaultOptions(OptionsResolver $resolver): void
     {
         $resolver

--- a/src/Swarrot/Processor/MemoryLimit/MemoryLimitProcessor.php
+++ b/src/Swarrot/Processor/MemoryLimit/MemoryLimitProcessor.php
@@ -20,9 +20,6 @@ class MemoryLimitProcessor implements ConfigurableInterface
         $this->logger = $logger ?: new NullLogger();
     }
 
-    /**
-     * {@inheritdoc}
-     */
     public function process(Message $message, array $options): bool
     {
         $return = $this->processor->process($message, $options);
@@ -44,9 +41,6 @@ class MemoryLimitProcessor implements ConfigurableInterface
         return $return;
     }
 
-    /**
-     * {@inheritdoc}
-     */
     public function setDefaultOptions(OptionsResolver $resolver): void
     {
         $resolver->setDefaults([

--- a/src/Swarrot/Processor/Retry/RetryProcessor.php
+++ b/src/Swarrot/Processor/Retry/RetryProcessor.php
@@ -26,9 +26,6 @@ class RetryProcessor implements ConfigurableInterface
         $this->logger = $logger ?? new NullLogger();
     }
 
-    /**
-     * {@inheritdoc}
-     */
     public function process(Message $message, array $options): bool
     {
         try {
@@ -84,9 +81,6 @@ class RetryProcessor implements ConfigurableInterface
         return true;
     }
 
-    /**
-     * {@inheritdoc}
-     */
     public function setDefaultOptions(OptionsResolver $resolver): void
     {
         $resolver

--- a/src/Swarrot/Processor/ServicesResetter/ServicesResetterProcessor.php
+++ b/src/Swarrot/Processor/ServicesResetter/ServicesResetterProcessor.php
@@ -22,9 +22,6 @@ class ServicesResetterProcessor implements ProcessorInterface
         $this->servicesResetter = $servicesResetter;
     }
 
-    /**
-     * {@inheritdoc}
-     */
     public function process(Message $message, array $options): bool
     {
         try {

--- a/src/Swarrot/Processor/SignalHandler/SignalHandlerProcessor.php
+++ b/src/Swarrot/Processor/SignalHandler/SignalHandlerProcessor.php
@@ -27,27 +27,18 @@ class SignalHandlerProcessor implements ConfigurableInterface, SleepyInterface, 
         $this->logger = $logger ?: new NullLogger();
     }
 
-    /**
-     * {@inheritdoc}
-     */
     public function setDefaultOptions(OptionsResolver $resolver): void
     {
         $resolver->setDefaults([
-            'signal_handler_signals' => \extension_loaded('pcntl') ? [SIGTERM, SIGINT, SIGQUIT] : [],
+            'signal_handler_signals' => \extension_loaded('pcntl') ? [\SIGTERM, \SIGINT, \SIGQUIT] : [],
         ]);
     }
 
-    /**
-     * {@inheritdoc}
-     */
     public function sleep(array $options): bool
     {
         return !$this::$shouldExit;
     }
 
-    /**
-     * {@inheritdoc}
-     */
     public function process(Message $message, array $options): bool
     {
         $return = $this->processor->process($message, $options);
@@ -59,9 +50,6 @@ class SignalHandlerProcessor implements ConfigurableInterface, SleepyInterface, 
         return $return;
     }
 
-    /**
-     * {@inheritdoc}
-     */
     public function initialize(array $options): void
     {
         if (!\extension_loaded('pcntl')) {

--- a/src/Swarrot/Processor/Stack/Builder.php
+++ b/src/Swarrot/Processor/Stack/Builder.php
@@ -2,6 +2,8 @@
 
 namespace Swarrot\Processor\Stack;
 
+use Swarrot\Processor\ProcessorInterface;
+
 class Builder
 {
     /**
@@ -44,6 +46,9 @@ class Builder
         return $this;
     }
 
+    /**
+     * @param ProcessorInterface $processor
+     */
     public function resolve($processor): StackedProcessor
     {
         $middlewares = [$processor];

--- a/src/Swarrot/Processor/Stack/Builder.php
+++ b/src/Swarrot/Processor/Stack/Builder.php
@@ -44,9 +44,6 @@ class Builder
         return $this;
     }
 
-    /**
-     * @param mixed $processor
-     */
     public function resolve($processor): StackedProcessor
     {
         $middlewares = [$processor];

--- a/src/Swarrot/Processor/Stack/StackedProcessor.php
+++ b/src/Swarrot/Processor/Stack/StackedProcessor.php
@@ -33,9 +33,6 @@ class StackedProcessor implements ConfigurableInterface, InitializableInterface,
         }
     }
 
-    /**
-     * {@inheritdoc}
-     */
     public function initialize(array $options): void
     {
         foreach ($this->middlewares as $middleware) {
@@ -45,17 +42,11 @@ class StackedProcessor implements ConfigurableInterface, InitializableInterface,
         }
     }
 
-    /**
-     * {@inheritdoc}
-     */
     public function process(Message $message, array $options): bool
     {
         return $this->processor->process($message, $options);
     }
 
-    /**
-     * {@inheritdoc}
-     */
     public function terminate(array $options): void
     {
         foreach ($this->middlewares as $middleware) {
@@ -65,9 +56,6 @@ class StackedProcessor implements ConfigurableInterface, InitializableInterface,
         }
     }
 
-    /**
-     * {@inheritdoc}
-     */
     public function sleep(array $options): bool
     {
         foreach ($this->middlewares as $middleware) {

--- a/src/Swarrot/Processor/XDeath/XDeathMaxCountProcessor.php
+++ b/src/Swarrot/Processor/XDeath/XDeathMaxCountProcessor.php
@@ -30,9 +30,6 @@ class XDeathMaxCountProcessor implements ConfigurableInterface
         $this->logger = $logger ?: new NullLogger();
     }
 
-    /**
-     * {@inheritdoc}
-     */
     public function setDefaultOptions(OptionsResolver $resolver): void
     {
         $resolver
@@ -46,9 +43,6 @@ class XDeathMaxCountProcessor implements ConfigurableInterface
             ->setAllowedTypes('x_death_max_count_fail_log_levels_map', 'array');
     }
 
-    /**
-     * {@inheritdoc}
-     */
     public function process(Message $message, array $options): bool
     {
         try {

--- a/src/Swarrot/Processor/XDeath/XDeathMaxLifetimeProcessor.php
+++ b/src/Swarrot/Processor/XDeath/XDeathMaxLifetimeProcessor.php
@@ -30,9 +30,6 @@ class XDeathMaxLifetimeProcessor implements ConfigurableInterface
         $this->logger = $logger ?: new NullLogger();
     }
 
-    /**
-     * {@inheritdoc}
-     */
     public function setDefaultOptions(OptionsResolver $resolver): void
     {
         $resolver
@@ -46,9 +43,6 @@ class XDeathMaxLifetimeProcessor implements ConfigurableInterface
             ->setAllowedTypes('x_death_max_lifetime_fail_log_levels_map', 'array');
     }
 
-    /**
-     * {@inheritdoc}
-     */
     public function process(Message $message, array $options): bool
     {
         try {

--- a/tests/Swarrot/Broker/MessageProvider/CallbackMessageProviderTest.php
+++ b/tests/Swarrot/Broker/MessageProvider/CallbackMessageProviderTest.php
@@ -44,8 +44,6 @@ class CallbackMessageProviderTest extends TestCase
 
     /**
      * @dataProvider callable_with_message_provider
-     *
-     * @param $callableProvider
      */
     public function test_get_with_messages_in_queue_return_message($callableProvider)
     {
@@ -88,8 +86,6 @@ class CallbackMessageProviderTest extends TestCase
 
     /**
      * @dataProvider callable_without_message_provider
-     *
-     * @param $callableProvider
      */
     public function test_get_without_messages_in_queue_return_null($callableProvider)
     {

--- a/tests/Swarrot/Broker/MessageProvider/CallbackMessageProviderTest.php
+++ b/tests/Swarrot/Broker/MessageProvider/CallbackMessageProviderTest.php
@@ -3,11 +3,14 @@
 namespace Swarrot\Tests\Broker\MessageProvider;
 
 use PHPUnit\Framework\TestCase;
+use Prophecy\PhpUnit\ProphecyTrait;
 use Swarrot\Broker\Message;
 use Swarrot\Broker\MessageProvider\CallbackMessageProvider;
 
 class CallbackMessageProviderTest extends TestCase
 {
+    use ProphecyTrait;
+
     public function callable_with_message_provider()
     {
         return [

--- a/tests/Swarrot/Broker/MessageProvider/PhpAmqpLibMessageProviderTest.php
+++ b/tests/Swarrot/Broker/MessageProvider/PhpAmqpLibMessageProviderTest.php
@@ -6,11 +6,14 @@ use PhpAmqpLib\Channel\AMQPChannel;
 use PhpAmqpLib\Message\AMQPMessage;
 use PhpAmqpLib\Wire\AMQPArray;
 use PHPUnit\Framework\TestCase;
+use Prophecy\PhpUnit\ProphecyTrait;
 use Swarrot\Broker\Message;
 use Swarrot\Broker\MessageProvider\PhpAmqpLibMessageProvider;
 
 class PhpAmqpLibMessageProviderTest extends TestCase
 {
+    use ProphecyTrait;
+
     public function test_get_with_messages_in_queue_return_message()
     {
         $channel = $this->prophesize(AMQPChannel::class);

--- a/tests/Swarrot/Broker/MessagePublisher/PeclPackageMessagePublisherTest.php
+++ b/tests/Swarrot/Broker/MessagePublisher/PeclPackageMessagePublisherTest.php
@@ -4,11 +4,14 @@ namespace Swarrot\Tests\Broker\MessagePublisher;
 
 use PHPUnit\Framework\TestCase;
 use Prophecy\Argument;
+use Prophecy\PhpUnit\ProphecyTrait;
 use Swarrot\Broker\Message;
 use Swarrot\Broker\MessagePublisher\PeclPackageMessagePublisher;
 
 class PeclPackageMessagePublisherTest extends TestCase
 {
+    use ProphecyTrait;
+
     protected function setUp(): void
     {
         if (!class_exists('AMQPConnection')) {

--- a/tests/Swarrot/Broker/MessagePublisher/PeclPackageMessagePublisherTest.php
+++ b/tests/Swarrot/Broker/MessagePublisher/PeclPackageMessagePublisherTest.php
@@ -130,7 +130,7 @@ class PeclPackageMessagePublisherTest extends TestCase
         $exchange->getChannel()->willReturn($channel->reveal());
         $exchange->publish('body', '', 0, [])->shouldBeCalledTimes(1);
 
-        $provider = new PeclPackageMessagePublisher($exchange->reveal(), AMQP_NOPARAM, null, true, 10);
+        $provider = new PeclPackageMessagePublisher($exchange->reveal(), \AMQP_NOPARAM, null, true, 10);
         $return = $provider->publish(
             new Message('body', [
                 'delivery_mode' => 0,

--- a/tests/Swarrot/Broker/MessagePublisher/PhpAmqpLibMessagePublisherTest.php
+++ b/tests/Swarrot/Broker/MessagePublisher/PhpAmqpLibMessagePublisherTest.php
@@ -6,11 +6,14 @@ use PhpAmqpLib\Channel\AMQPChannel;
 use PhpAmqpLib\Message\AMQPMessage;
 use PHPUnit\Framework\TestCase;
 use Prophecy\Argument;
+use Prophecy\PhpUnit\ProphecyTrait;
 use Swarrot\Broker\Message;
 use Swarrot\Broker\MessagePublisher\PhpAmqpLibMessagePublisher;
 
 class PhpAmqpLibMessagePublisherTest extends TestCase
 {
+    use ProphecyTrait;
+
     public function test_publish_with_valid_message()
     {
         $channel = $this->prophesize(AMQPChannel::class);

--- a/tests/Swarrot/Broker/MessagePublisher/PhpAmqpLibMessagePublisherTest.php
+++ b/tests/Swarrot/Broker/MessagePublisher/PhpAmqpLibMessagePublisherTest.php
@@ -46,13 +46,13 @@ class PhpAmqpLibMessagePublisherTest extends TestCase
                 $properties = $message->get_properties();
 
                 return
-                    'body' === $message->body &&
-                    $properties['application_headers']['int_header'] === ['I', 42] &&
-                    $properties['application_headers']['string_header'] === ['S', 'my_value'] &&
-                    $properties['application_headers']['array_header'] === ['A', ['foo' => 'bar']] &&
-                    !isset($properties['headers']) &&
-                    $message->serialize_properties()
-                    ;
+                    'body' === $message->body
+                    && $properties['application_headers']['int_header'] === ['I', 42]
+                    && $properties['application_headers']['string_header'] === ['S', 'my_value']
+                    && $properties['application_headers']['array_header'] === ['A', ['foo' => 'bar']]
+                    && !isset($properties['headers'])
+                    && $message->serialize_properties()
+                ;
             }),
             Argument::exact('swarrot'),
             Argument::exact('')

--- a/tests/Swarrot/ConsumerTest.php
+++ b/tests/Swarrot/ConsumerTest.php
@@ -4,6 +4,7 @@ namespace Swarrot\Tests;
 
 use PHPUnit\Framework\TestCase;
 use Prophecy\Argument;
+use Prophecy\PhpUnit\ProphecyTrait;
 use Swarrot\Broker\Message;
 use Swarrot\Broker\MessageProvider\MessageProviderInterface;
 use Swarrot\Consumer;
@@ -16,6 +17,8 @@ use Symfony\Component\OptionsResolver\OptionsResolver;
 
 class ConsumerTest extends TestCase
 {
+    use ProphecyTrait;
+
     public function test_it_is_initializable()
     {
         $provider = $this->prophesize(MessageProviderInterface::class);

--- a/tests/Swarrot/Processor/Ack/AckProcessorTest.php
+++ b/tests/Swarrot/Processor/Ack/AckProcessorTest.php
@@ -3,6 +3,7 @@
 namespace Swarrot\Tests\Processor\Ack;
 
 use PHPUnit\Framework\TestCase;
+use Prophecy\PhpUnit\ProphecyTrait;
 use Psr\Log\LoggerInterface;
 use Swarrot\Broker\Message;
 use Swarrot\Broker\MessageProvider\MessageProviderInterface;
@@ -12,6 +13,8 @@ use Symfony\Component\OptionsResolver\OptionsResolver;
 
 class AckProcessorTest extends TestCase
 {
+    use ProphecyTrait;
+
     public function test_it_is_initializable_without_a_logger()
     {
         $processor = $this->prophesize(ProcessorInterface::class);

--- a/tests/Swarrot/Processor/Callback/CallbackProcessorTest.php
+++ b/tests/Swarrot/Processor/Callback/CallbackProcessorTest.php
@@ -1,6 +1,6 @@
 <?php
 
-namespace Swarrot\Tests\Processor\Ack;
+namespace Swarrot\Tests\Processor\Callback;
 
 use PHPUnit\Framework\TestCase;
 use Swarrot\Broker\Message;

--- a/tests/Swarrot/Processor/Callback/CallbackProcessorTest.php
+++ b/tests/Swarrot/Processor/Callback/CallbackProcessorTest.php
@@ -3,11 +3,14 @@
 namespace Swarrot\Tests\Processor\Callback;
 
 use PHPUnit\Framework\TestCase;
+use Prophecy\PhpUnit\ProphecyTrait;
 use Swarrot\Broker\Message;
 use Swarrot\Processor\Callback\CallbackProcessor;
 
 class CallbackProcessorTest extends TestCase
 {
+    use ProphecyTrait;
+
     public function callable_provider()
     {
         return [

--- a/tests/Swarrot/Processor/Doctrine/ConnectionProcessorTest.php
+++ b/tests/Swarrot/Processor/Doctrine/ConnectionProcessorTest.php
@@ -10,12 +10,15 @@ use Doctrine\DBAL\Platforms\SqlitePlatform;
 use Doctrine\Persistence\ConnectionRegistry;
 use PHPUnit\Framework\TestCase;
 use Prophecy\Argument;
+use Prophecy\PhpUnit\ProphecyTrait;
 use Swarrot\Broker\Message;
 use Swarrot\Processor\Doctrine\ConnectionProcessor;
 use Swarrot\Processor\ProcessorInterface;
 
 class ConnectionProcessorTest extends TestCase
 {
+    use ProphecyTrait;
+
     public function test()
     {
         $message = new Message();

--- a/tests/Swarrot/Processor/Doctrine/ConnectionProcessorTest.php
+++ b/tests/Swarrot/Processor/Doctrine/ConnectionProcessorTest.php
@@ -1,6 +1,6 @@
 <?php
 
-namespace Swarrot\Tests\Processor\Ack;
+namespace Swarrot\Tests\Processor\Doctrine;
 
 use Doctrine\DBAL\Connection;
 use Doctrine\DBAL\Connections\MasterSlaveConnection;

--- a/tests/Swarrot/Processor/Doctrine/ConnectionProcessorTest.php
+++ b/tests/Swarrot/Processor/Doctrine/ConnectionProcessorTest.php
@@ -166,7 +166,7 @@ class ConnectionProcessorTest extends TestCase
         $this->expectException(\InvalidArgumentException::class);
         $this->expectExceptionMessage('$connections must be an array of Connection, but one of the elements was stdClass');
 
-        new ConnectionProcessor($innerProcessorProphecy->reveal(), [new \StdClass()]);
+        new ConnectionProcessor($innerProcessorProphecy->reveal(), [new \stdClass()]);
     }
 
     public function testAcceptEmptyConnections()

--- a/tests/Swarrot/Processor/Doctrine/ObjectManagerProcessorTest.php
+++ b/tests/Swarrot/Processor/Doctrine/ObjectManagerProcessorTest.php
@@ -1,6 +1,6 @@
 <?php
 
-namespace Swarrot\Tests\Processor\Ack;
+namespace Swarrot\Tests\Processor\Doctrine;
 
 use Doctrine\Persistence\ManagerRegistry;
 use Doctrine\Persistence\ObjectManager;

--- a/tests/Swarrot/Processor/Doctrine/ObjectManagerProcessorTest.php
+++ b/tests/Swarrot/Processor/Doctrine/ObjectManagerProcessorTest.php
@@ -5,12 +5,15 @@ namespace Swarrot\Tests\Processor\Doctrine;
 use Doctrine\Persistence\ManagerRegistry;
 use Doctrine\Persistence\ObjectManager;
 use PHPUnit\Framework\TestCase;
+use Prophecy\PhpUnit\ProphecyTrait;
 use Swarrot\Broker\Message;
 use Swarrot\Processor\Doctrine\ObjectManagerProcessor;
 use Swarrot\Processor\ProcessorInterface;
 
 class ObjectManagerProcessorTest extends TestCase
 {
+    use ProphecyTrait;
+
     public function test()
     {
         $message = new Message();

--- a/tests/Swarrot/Processor/ExceptionCatcher/ExceptionCatcherTest.php
+++ b/tests/Swarrot/Processor/ExceptionCatcher/ExceptionCatcherTest.php
@@ -4,6 +4,7 @@ namespace Swarrot\Tests\Processor\ExceptionCatcher;
 
 use PHPUnit\Framework\TestCase;
 use Prophecy\Argument;
+use Prophecy\PhpUnit\ProphecyTrait;
 use Psr\Log\LoggerInterface;
 use Swarrot\Broker\Message;
 use Swarrot\Processor\ExceptionCatcher\ExceptionCatcherProcessor;
@@ -11,6 +12,8 @@ use Swarrot\Processor\ProcessorInterface;
 
 class ExceptionCatcherTest extends TestCase
 {
+    use ProphecyTrait;
+
     public function test_it_is_initializable_without_a_logger()
     {
         $processor = $this->prophesize(ProcessorInterface::class);

--- a/tests/Swarrot/Processor/Insomniac/InsomniacProcessorTest.php
+++ b/tests/Swarrot/Processor/Insomniac/InsomniacProcessorTest.php
@@ -3,12 +3,15 @@
 namespace Swarrot\Tests\Processor\Insomniac;
 
 use PHPUnit\Framework\TestCase;
+use Prophecy\PhpUnit\ProphecyTrait;
 use Swarrot\Broker\Message;
 use Swarrot\Processor\Insomniac\InsomniacProcessor;
 use Swarrot\Processor\ProcessorInterface;
 
 class InsomniacProcessorTest extends TestCase
 {
+    use ProphecyTrait;
+
     public function test()
     {
         $message = new Message();

--- a/tests/Swarrot/Processor/InstantRetry/InstantRetryProcessorTest.php
+++ b/tests/Swarrot/Processor/InstantRetry/InstantRetryProcessorTest.php
@@ -4,6 +4,7 @@ namespace Swarrot\Tests\Processor\InstantRetry;
 
 use PHPUnit\Framework\TestCase;
 use Prophecy\Argument;
+use Prophecy\PhpUnit\ProphecyTrait;
 use Psr\Log\LoggerInterface;
 use Psr\Log\LogLevel;
 use Swarrot\Broker\Message;
@@ -12,6 +13,8 @@ use Swarrot\Processor\ProcessorInterface;
 
 class InstantRetryProcessorTest extends TestCase
 {
+    use ProphecyTrait;
+
     public function test_it_is_initializable_without_a_logger()
     {
         $processor = $this->prophesize(ProcessorInterface::class);

--- a/tests/Swarrot/Processor/MaxExecutionTime/MaxExecutionTimeProcessorTest.php
+++ b/tests/Swarrot/Processor/MaxExecutionTime/MaxExecutionTimeProcessorTest.php
@@ -3,6 +3,7 @@
 namespace Swarrot\Tests\Processor\MaxExecutionTime;
 
 use PHPUnit\Framework\TestCase;
+use Prophecy\PhpUnit\ProphecyTrait;
 use Psr\Log\LoggerInterface;
 use Swarrot\Broker\Message;
 use Swarrot\Processor\MaxExecutionTime\MaxExecutionTimeProcessor;
@@ -10,6 +11,8 @@ use Swarrot\Processor\ProcessorInterface;
 
 class MaxExecutionTimeProcessorTest extends TestCase
 {
+    use ProphecyTrait;
+
     public function test_it_is_initializable_without_a_logger()
     {
         $processor = $this->prophesize(ProcessorInterface::class);

--- a/tests/Swarrot/Processor/MaxMessages/MaxMessagesProcessorTest.php
+++ b/tests/Swarrot/Processor/MaxMessages/MaxMessagesProcessorTest.php
@@ -3,6 +3,7 @@
 namespace Swarrot\Tests\Processor\MaxMessages;
 
 use PHPUnit\Framework\TestCase;
+use Prophecy\PhpUnit\ProphecyTrait;
 use Psr\Log\LoggerInterface;
 use Swarrot\Broker\Message;
 use Swarrot\Processor\MaxMessages\MaxMessagesProcessor;
@@ -10,6 +11,8 @@ use Swarrot\Processor\ProcessorInterface;
 
 class MaxMessagesProcessorTest extends TestCase
 {
+    use ProphecyTrait;
+
     public function test_it_is_initializable_without_a_logger()
     {
         $processor = $this->prophesize(ProcessorInterface::class);

--- a/tests/Swarrot/Processor/MemoryLimit/MemoryLimitProcessorTest.php
+++ b/tests/Swarrot/Processor/MemoryLimit/MemoryLimitProcessorTest.php
@@ -3,6 +3,7 @@
 namespace Swarrot\Tests\Processor\MemoryLimit;
 
 use PHPUnit\Framework\TestCase;
+use Prophecy\PhpUnit\ProphecyTrait;
 use Psr\Log\LoggerInterface;
 use Swarrot\Broker\Message;
 use Swarrot\Processor\MemoryLimit\MemoryLimitProcessor;
@@ -10,6 +11,8 @@ use Swarrot\Processor\ProcessorInterface;
 
 class MemoryLimitProcessorTest extends TestCase
 {
+    use ProphecyTrait;
+
     public function test_it_is_initializable_without_a_logger()
     {
         $processor = $this->prophesize(ProcessorInterface::class);

--- a/tests/Swarrot/Processor/Retry/RetryProcessorTest.php
+++ b/tests/Swarrot/Processor/Retry/RetryProcessorTest.php
@@ -4,6 +4,7 @@ namespace Swarrot\Tests\Processor\Retry;
 
 use PHPUnit\Framework\TestCase;
 use Prophecy\Argument;
+use Prophecy\PhpUnit\ProphecyTrait;
 use Psr\Log\LoggerInterface;
 use Psr\Log\LogLevel;
 use Swarrot\Broker\Message;
@@ -15,6 +16,8 @@ use Symfony\Component\OptionsResolver\OptionsResolver;
 
 class RetryProcessorTest extends TestCase
 {
+    use ProphecyTrait;
+
     public function test_it_is_initializable_without_a_logger()
     {
         $processor = $this->prophesize(ProcessorInterface::class);

--- a/tests/Swarrot/Processor/ServicesResetter/ServicesResetterProcessorTest.php
+++ b/tests/Swarrot/Processor/ServicesResetter/ServicesResetterProcessorTest.php
@@ -3,6 +3,7 @@
 namespace Swarrot\Tests\Processor\ServicesResetter;
 
 use PHPUnit\Framework\TestCase;
+use Prophecy\PhpUnit\ProphecyTrait;
 use Swarrot\Broker\Message;
 use Swarrot\Processor\ProcessorInterface;
 use Swarrot\Processor\ServicesResetter\ServicesResetterProcessor;
@@ -10,6 +11,8 @@ use Symfony\Contracts\Service\ResetInterface;
 
 class ServicesResetterProcessorTest extends TestCase
 {
+    use ProphecyTrait;
+
     public function test()
     {
         $message = new Message();

--- a/tests/Swarrot/Processor/SignalHandler/SignalHandlerProcessorTest.php
+++ b/tests/Swarrot/Processor/SignalHandler/SignalHandlerProcessorTest.php
@@ -3,6 +3,7 @@
 namespace Swarrot\Tests\Processor\SignalHandler;
 
 use PHPUnit\Framework\TestCase;
+use Prophecy\PhpUnit\ProphecyTrait;
 use Psr\Log\LoggerInterface;
 use Swarrot\Broker\Message;
 use Swarrot\Processor\ProcessorInterface;
@@ -10,6 +11,8 @@ use Swarrot\Processor\SignalHandler\SignalHandlerProcessor;
 
 class SignalHandlerProcessorTest extends TestCase
 {
+    use ProphecyTrait;
+
     public function test_it_is_initializable_without_a_logger()
     {
         $processor = $this->prophesize(ProcessorInterface::class);

--- a/tests/Swarrot/Processor/Stack/StackedProcessorTest.php
+++ b/tests/Swarrot/Processor/Stack/StackedProcessorTest.php
@@ -4,6 +4,7 @@ namespace Swarrot\Tests\Processor\Stack;
 
 use PHPUnit\Framework\TestCase;
 use Prophecy\Argument;
+use Prophecy\PhpUnit\ProphecyTrait;
 use Swarrot\Broker\Message;
 use Swarrot\Processor\InitializableInterface;
 use Swarrot\Processor\ProcessorInterface;
@@ -13,6 +14,8 @@ use Swarrot\Processor\TerminableInterface;
 
 class StackedProcessorTest extends TestCase
 {
+    use ProphecyTrait;
+
     public function test_it_is_initializable()
     {
         $p1 = $this->prophesize(ProcessorInterface::class);

--- a/tests/Swarrot/Processor/XDeath/XDeathMaxCountProcessorTest.php
+++ b/tests/Swarrot/Processor/XDeath/XDeathMaxCountProcessorTest.php
@@ -6,6 +6,7 @@ use PhpAmqpLib\Wire\AMQPArray;
 use PhpAmqpLib\Wire\AMQPTable;
 use PHPUnit\Framework\TestCase;
 use Prophecy\Argument;
+use Prophecy\PhpUnit\ProphecyTrait;
 use Psr\Log\LoggerInterface;
 use Psr\Log\LogLevel;
 use Swarrot\Broker\Message;
@@ -15,6 +16,8 @@ use Symfony\Component\OptionsResolver\OptionsResolver;
 
 class XDeathMaxCountProcessorTest extends TestCase
 {
+    use ProphecyTrait;
+
     public function test_it_is_initializable_without_a_logger()
     {
         $processorMock = $this->prophesize(ProcessorInterface::class);

--- a/tests/Swarrot/Processor/XDeath/XDeathMaxCountProcessorTest.php
+++ b/tests/Swarrot/Processor/XDeath/XDeathMaxCountProcessorTest.php
@@ -152,8 +152,6 @@ class XDeathMaxCountProcessorTest extends TestCase
 
     /**
      * @dataProvider messageProvider
-     *
-     * @param $message
      */
     public function test_it_should_not_rethrow_with_x_death_max_count_reached($message)
     {
@@ -184,8 +182,6 @@ class XDeathMaxCountProcessorTest extends TestCase
 
     /**
      * @dataProvider messageProvider
-     *
-     * @param $message
      */
     public function test_it_should_rethrow_with_x_death_max_count_reached_and_callback_returns_null($message)
     {
@@ -218,8 +214,6 @@ class XDeathMaxCountProcessorTest extends TestCase
 
     /**
      * @dataProvider messageProvider
-     *
-     * @param $message
      */
     public function test_it_should_rethrow_with_x_death_max_count_not_reached($message)
     {
@@ -284,8 +278,6 @@ class XDeathMaxCountProcessorTest extends TestCase
 
     /**
      * @dataProvider messageProvider
-     *
-     * @param $message
      */
     public function test_it_should_log_a_custom_log_level_with_x_death_max_count_not_reached($message)
     {
@@ -320,8 +312,6 @@ class XDeathMaxCountProcessorTest extends TestCase
 
     /**
      * @dataProvider messageProvider
-     *
-     * @param $message
      */
     public function test_it_should_log_x_death_max_count_not_found($message)
     {

--- a/tests/Swarrot/Processor/XDeath/XDeathMaxLifetimeProcessorTest.php
+++ b/tests/Swarrot/Processor/XDeath/XDeathMaxLifetimeProcessorTest.php
@@ -6,6 +6,7 @@ use PhpAmqpLib\Wire\AMQPArray;
 use PhpAmqpLib\Wire\AMQPTable;
 use PHPUnit\Framework\TestCase;
 use Prophecy\Argument;
+use Prophecy\PhpUnit\ProphecyTrait;
 use Psr\Log\LoggerInterface;
 use Psr\Log\LogLevel;
 use Swarrot\Broker\Message;
@@ -15,6 +16,8 @@ use Symfony\Component\OptionsResolver\OptionsResolver;
 
 class XDeathMaxLifetimeProcessorTest extends TestCase
 {
+    use ProphecyTrait;
+
     public function test_it_is_initializable_without_a_logger()
     {
         $processorMock = $this->prophesize(ProcessorInterface::class);


### PR DESCRIPTION
As discussed in https://github.com/swarrot/swarrot/pull/248#issuecomment-1717387397, this moves php-cs-fixer and phpstan to be managed by composer instead of the swarrot-phpqa image maintained in https://github.com/swarrot/phpqa (this package should be archived now).

Thanks to this change, we are now using up-to-date versions of PHP-CS-Fixer (which was using v2 before) and phpstan.
I also took this opportunity to update PHPUnit to 9.6 (I haven't updated to 10.x because we use the deprecation tooling of symfony/phpunit-bridge which is not compatible yet)