### PR TITLE
Mark all classes as becoming final in the next major version

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,7 @@ This project adheres to [Semantic Versioning](http://semver.org/).
 
 - Remove support for unmaintained Symfony versions. The min version is now 5.4
 - Mark all classes as `@final` when they will become final in 5.0. Composition should be used instead of inheritance.
+- Add MemoryResetProcessor
 
 ## 4.15.0 - 2023-09-12
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,7 @@ This project adheres to [Semantic Versioning](http://semver.org/).
 ## [Unreleased]
 
 - Remove support for unmaintained Symfony versions. The min version is now 5.4
+- Mark all classes as `@final` when they will become final in 5.0. Composition should be used instead of inheritance.
 
 ## 4.15.0 - 2023-09-12
 

--- a/src/Swarrot/Broker/Message.php
+++ b/src/Swarrot/Broker/Message.php
@@ -2,6 +2,9 @@
 
 namespace Swarrot\Broker;
 
+/**
+ * @final since 4.16.0
+ */
 class Message
 {
     private $body;

--- a/src/Swarrot/Broker/MessageProvider/CallbackMessageProvider.php
+++ b/src/Swarrot/Broker/MessageProvider/CallbackMessageProvider.php
@@ -4,6 +4,9 @@ namespace Swarrot\Broker\MessageProvider;
 
 use Swarrot\Broker\Message;
 
+/**
+ * @final since 4.16.0
+ */
 class CallbackMessageProvider implements MessageProviderInterface
 {
     private $get;

--- a/src/Swarrot/Broker/MessageProvider/PeclPackageMessageProvider.php
+++ b/src/Swarrot/Broker/MessageProvider/PeclPackageMessageProvider.php
@@ -4,6 +4,9 @@ namespace Swarrot\Broker\MessageProvider;
 
 use Swarrot\Broker\Message;
 
+/**
+ * @final since 4.16.0
+ */
 class PeclPackageMessageProvider implements MessageProviderInterface
 {
     private $queue;

--- a/src/Swarrot/Broker/MessageProvider/PhpAmqpLibMessageProvider.php
+++ b/src/Swarrot/Broker/MessageProvider/PhpAmqpLibMessageProvider.php
@@ -6,6 +6,9 @@ use PhpAmqpLib\Channel\AMQPChannel;
 use PhpAmqpLib\Wire\AMQPArray;
 use Swarrot\Broker\Message;
 
+/**
+ * @final since 4.16.0
+ */
 class PhpAmqpLibMessageProvider implements MessageProviderInterface
 {
     private $channel;

--- a/src/Swarrot/Broker/MessagePublisher/PeclPackageMessagePublisher.php
+++ b/src/Swarrot/Broker/MessagePublisher/PeclPackageMessagePublisher.php
@@ -6,6 +6,9 @@ use Psr\Log\LoggerInterface;
 use Psr\Log\NullLogger;
 use Swarrot\Broker\Message;
 
+/**
+ * @final since 4.16.0
+ */
 class PeclPackageMessagePublisher implements MessagePublisherInterface
 {
     private $exchange;

--- a/src/Swarrot/Broker/MessagePublisher/PhpAmqpLibMessagePublisher.php
+++ b/src/Swarrot/Broker/MessagePublisher/PhpAmqpLibMessagePublisher.php
@@ -6,6 +6,9 @@ use PhpAmqpLib\Channel\AMQPChannel;
 use PhpAmqpLib\Message\AMQPMessage;
 use Swarrot\Broker\Message;
 
+/**
+ * @final since 4.16.0
+ */
 class PhpAmqpLibMessagePublisher implements MessagePublisherInterface
 {
     /** @var AMQPChannel */

--- a/src/Swarrot/Consumer.php
+++ b/src/Swarrot/Consumer.php
@@ -12,6 +12,9 @@ use Swarrot\Processor\SleepyInterface;
 use Swarrot\Processor\TerminableInterface;
 use Symfony\Component\OptionsResolver\OptionsResolver;
 
+/**
+ * @final since 4.16.0
+ */
 class Consumer
 {
     private $messageProvider;

--- a/src/Swarrot/Processor/Ack/AckProcessor.php
+++ b/src/Swarrot/Processor/Ack/AckProcessor.php
@@ -10,6 +10,9 @@ use Swarrot\Processor\ConfigurableInterface;
 use Swarrot\Processor\ProcessorInterface;
 use Symfony\Component\OptionsResolver\OptionsResolver;
 
+/**
+ * @final since 4.16.0
+ */
 class AckProcessor implements ConfigurableInterface
 {
     private $processor;

--- a/src/Swarrot/Processor/Callback/CallbackProcessor.php
+++ b/src/Swarrot/Processor/Callback/CallbackProcessor.php
@@ -5,6 +5,9 @@ namespace Swarrot\Processor\Callback;
 use Swarrot\Broker\Message;
 use Swarrot\Processor\ProcessorInterface;
 
+/**
+ * @final since 4.16.0
+ */
 class CallbackProcessor implements ProcessorInterface
 {
     private $process;

--- a/src/Swarrot/Processor/Doctrine/ConnectionProcessor.php
+++ b/src/Swarrot/Processor/Doctrine/ConnectionProcessor.php
@@ -15,6 +15,8 @@ use Symfony\Component\OptionsResolver\OptionsResolver;
 
 /**
  * @author Adrien Brault <adrien.brault@gmail.com>
+ *
+ * @final since 4.16.0
  */
 class ConnectionProcessor implements ConfigurableInterface
 {

--- a/src/Swarrot/Processor/Doctrine/ObjectManagerProcessor.php
+++ b/src/Swarrot/Processor/Doctrine/ObjectManagerProcessor.php
@@ -8,6 +8,8 @@ use Swarrot\Processor\ProcessorInterface;
 
 /**
  * @author Adrien Brault <adrien.brault@gmail.com>
+ *
+ * @final since 4.16.0
  */
 class ObjectManagerProcessor implements ProcessorInterface
 {

--- a/src/Swarrot/Processor/ExceptionCatcher/ExceptionCatcherProcessor.php
+++ b/src/Swarrot/Processor/ExceptionCatcher/ExceptionCatcherProcessor.php
@@ -7,6 +7,9 @@ use Psr\Log\NullLogger;
 use Swarrot\Broker\Message;
 use Swarrot\Processor\ProcessorInterface;
 
+/**
+ * @final since 4.16.0
+ */
 class ExceptionCatcherProcessor implements ProcessorInterface
 {
     private $processor;

--- a/src/Swarrot/Processor/Insomniac/InsomniacProcessor.php
+++ b/src/Swarrot/Processor/Insomniac/InsomniacProcessor.php
@@ -8,6 +8,9 @@ use Swarrot\Broker\Message;
 use Swarrot\Processor\ProcessorInterface;
 use Swarrot\Processor\SleepyInterface;
 
+/**
+ * @final since 4.16.0
+ */
 class InsomniacProcessor implements SleepyInterface
 {
     private $processor;

--- a/src/Swarrot/Processor/InstantRetry/InstantRetryProcessor.php
+++ b/src/Swarrot/Processor/InstantRetry/InstantRetryProcessor.php
@@ -10,6 +10,9 @@ use Swarrot\Processor\ConfigurableInterface;
 use Swarrot\Processor\ProcessorInterface;
 use Symfony\Component\OptionsResolver\OptionsResolver;
 
+/**
+ * @final since 4.16.0
+ */
 class InstantRetryProcessor implements ConfigurableInterface
 {
     private $processor;

--- a/src/Swarrot/Processor/MaxExecutionTime/MaxExecutionTimeProcessor.php
+++ b/src/Swarrot/Processor/MaxExecutionTime/MaxExecutionTimeProcessor.php
@@ -11,6 +11,9 @@ use Swarrot\Processor\ProcessorInterface;
 use Swarrot\Processor\SleepyInterface;
 use Symfony\Component\OptionsResolver\OptionsResolver;
 
+/**
+ * @final since 4.16.0
+ */
 class MaxExecutionTimeProcessor implements ConfigurableInterface, InitializableInterface, SleepyInterface
 {
     private $processor;

--- a/src/Swarrot/Processor/MaxMessages/MaxMessagesProcessor.php
+++ b/src/Swarrot/Processor/MaxMessages/MaxMessagesProcessor.php
@@ -9,6 +9,9 @@ use Swarrot\Processor\ConfigurableInterface;
 use Swarrot\Processor\ProcessorInterface;
 use Symfony\Component\OptionsResolver\OptionsResolver;
 
+/**
+ * @final since 4.16.0
+ */
 class MaxMessagesProcessor implements ConfigurableInterface
 {
     private $processor;

--- a/src/Swarrot/Processor/MemoryLimit/MemoryLimitProcessor.php
+++ b/src/Swarrot/Processor/MemoryLimit/MemoryLimitProcessor.php
@@ -9,6 +9,9 @@ use Swarrot\Processor\ConfigurableInterface;
 use Swarrot\Processor\ProcessorInterface;
 use Symfony\Component\OptionsResolver\OptionsResolver;
 
+/**
+ * @final since 4.16.0
+ */
 class MemoryLimitProcessor implements ConfigurableInterface
 {
     private $processor;

--- a/src/Swarrot/Processor/MemoryReset/MemoryResetProcessor.php
+++ b/src/Swarrot/Processor/MemoryReset/MemoryResetProcessor.php
@@ -5,7 +5,7 @@ namespace Swarrot\Processor\MemoryReset;
 use Swarrot\Broker\Message;
 use Swarrot\Processor\ProcessorInterface;
 
-class MemoryResetProcessor implements ProcessorInterface
+final class MemoryResetProcessor implements ProcessorInterface
 {
     private ProcessorInterface $processor;
 

--- a/src/Swarrot/Processor/Retry/RetryProcessor.php
+++ b/src/Swarrot/Processor/Retry/RetryProcessor.php
@@ -13,6 +13,9 @@ use Symfony\Component\OptionsResolver\Exception\MissingOptionsException;
 use Symfony\Component\OptionsResolver\Options;
 use Symfony\Component\OptionsResolver\OptionsResolver;
 
+/**
+ * @final since 4.16.0
+ */
 class RetryProcessor implements ConfigurableInterface
 {
     private $processor;

--- a/src/Swarrot/Processor/ServicesResetter/ServicesResetterProcessor.php
+++ b/src/Swarrot/Processor/ServicesResetter/ServicesResetterProcessor.php
@@ -10,6 +10,8 @@ use Symfony\Contracts\Service\ResetInterface;
 
 /**
  * @author Pierrick Vignand <pierrick.vignand@gmail.com>
+ *
+ * @final since 4.16.0
  */
 class ServicesResetterProcessor implements ProcessorInterface
 {

--- a/src/Swarrot/Processor/SignalHandler/SignalHandlerProcessor.php
+++ b/src/Swarrot/Processor/SignalHandler/SignalHandlerProcessor.php
@@ -11,6 +11,9 @@ use Swarrot\Processor\ProcessorInterface;
 use Swarrot\Processor\SleepyInterface;
 use Symfony\Component\OptionsResolver\OptionsResolver;
 
+/**
+ * @final since 4.16.0
+ */
 class SignalHandlerProcessor implements ConfigurableInterface, SleepyInterface, InitializableInterface
 {
     /**

--- a/src/Swarrot/Processor/Stack/Builder.php
+++ b/src/Swarrot/Processor/Stack/Builder.php
@@ -4,6 +4,9 @@ namespace Swarrot\Processor\Stack;
 
 use Swarrot\Processor\ProcessorInterface;
 
+/**
+ * @final since 4.16.0
+ */
 class Builder
 {
     /**

--- a/src/Swarrot/Processor/Stack/StackedProcessor.php
+++ b/src/Swarrot/Processor/Stack/StackedProcessor.php
@@ -10,6 +10,9 @@ use Swarrot\Processor\SleepyInterface;
 use Swarrot\Processor\TerminableInterface;
 use Symfony\Component\OptionsResolver\OptionsResolver;
 
+/**
+ * @final since 4.16.0
+ */
 class StackedProcessor implements ConfigurableInterface, InitializableInterface, TerminableInterface, SleepyInterface
 {
     private $processor;

--- a/src/Swarrot/Processor/XDeath/XDeathMaxCountProcessor.php
+++ b/src/Swarrot/Processor/XDeath/XDeathMaxCountProcessor.php
@@ -11,6 +11,9 @@ use Swarrot\Processor\ConfigurableInterface;
 use Swarrot\Processor\ProcessorInterface;
 use Symfony\Component\OptionsResolver\OptionsResolver;
 
+/**
+ * @final since 4.16.0
+ */
 class XDeathMaxCountProcessor implements ConfigurableInterface
 {
     private $processor;

--- a/src/Swarrot/Processor/XDeath/XDeathMaxLifetimeProcessor.php
+++ b/src/Swarrot/Processor/XDeath/XDeathMaxLifetimeProcessor.php
@@ -11,6 +11,9 @@ use Swarrot\Processor\ConfigurableInterface;
 use Swarrot\Processor\ProcessorInterface;
 use Symfony\Component\OptionsResolver\OptionsResolver;
 
+/**
+ * @final since 4.16.0
+ */
 class XDeathMaxLifetimeProcessor implements ConfigurableInterface
 {
     private $processor;


### PR DESCRIPTION
As long as classes are marked as `@final since ...`, they are still subject to the normal BC rules for non-final classes. The next major version will either make them final or change the tag to `@final` which will make them subject to the BC rules of final classes (i.e. not considering it a change a BC break if it can only break child classes).

Classes in the library are not meant to be extended through inheritance. Processors are naturally based on composition which is the way to customize the library.