### PR TITLE
Use static data providers in tests

### DIFF
--- a/tests/Swarrot/Broker/MessageProvider/CallbackMessageProviderTest.php
+++ b/tests/Swarrot/Broker/MessageProvider/CallbackMessageProviderTest.php
@@ -11,7 +11,7 @@ class CallbackMessageProviderTest extends TestCase
 {
     use ProphecyTrait;
 
-    public function callable_with_message_provider()
+    public static function callable_with_message_provider()
     {
         return [
             [
@@ -53,7 +53,7 @@ class CallbackMessageProviderTest extends TestCase
         $this->assertInstanceOf(Message::class, $message);
     }
 
-    public function callable_without_message_provider()
+    public static function callable_without_message_provider()
     {
         return [
             [

--- a/tests/Swarrot/Processor/Callback/CallbackProcessorTest.php
+++ b/tests/Swarrot/Processor/Callback/CallbackProcessorTest.php
@@ -11,7 +11,7 @@ class CallbackProcessorTest extends TestCase
 {
     use ProphecyTrait;
 
-    public function callable_provider()
+    public static function callable_provider()
     {
         return [
             [

--- a/tests/Swarrot/Processor/XDeath/XDeathMaxCountProcessorTest.php
+++ b/tests/Swarrot/Processor/XDeath/XDeathMaxCountProcessorTest.php
@@ -104,7 +104,7 @@ class XDeathMaxCountProcessorTest extends TestCase
         ], $config);
     }
 
-    public function messageProvider()
+    public static function messageProvider()
     {
         $data = [
             [

--- a/tests/Swarrot/Processor/XDeath/XDeathMaxLifetimeProcessorTest.php
+++ b/tests/Swarrot/Processor/XDeath/XDeathMaxLifetimeProcessorTest.php
@@ -106,7 +106,7 @@ class XDeathMaxLifetimeProcessorTest extends TestCase
         ], $config);
     }
 
-    public function messageProvider()
+    public static function messageProvider()
     {
         $data = [
             [


### PR DESCRIPTION
PHPUnit 10 deprecates using non-static methods as data providers. Even though we are still on PHPUnit 9.6, there is no harm using static methods already.