### PR TITLE
Drop support for unmaintained Doctrine versions

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,8 @@ This project adheres to [Semantic Versioning](http://semver.org/).
 
 ## [Unreleased]
 
+- Drop support for unmaintained Doctrine versions
+
 ## 4.16.0 - 2023-09-20
 
 - Remove support for unmaintained Symfony versions. The min version is now 5.4

--- a/composer.json
+++ b/composer.json
@@ -16,8 +16,8 @@
         "psr/log": "^1.0 || ^2.0 || ^3.0"
     },
     "require-dev": {
-        "doctrine/common": "^2.9",
-        "doctrine/dbal": "^2.4",
+        "doctrine/persistence": "^3.0",
+        "doctrine/dbal": "^3.0",
         "friendsofphp/php-cs-fixer": "^3.27",
         "php-amqplib/php-amqplib": "^2.1 || ^3.0",
         "phpspec/prophecy": "^1.15",

--- a/src/Swarrot/Processor/Doctrine/ConnectionProcessor.php
+++ b/src/Swarrot/Processor/Doctrine/ConnectionProcessor.php
@@ -3,10 +3,8 @@
 namespace Swarrot\Processor\Doctrine;
 
 use Doctrine\DBAL\Connection;
-use Doctrine\DBAL\Connections\MasterSlaveConnection;
 use Doctrine\DBAL\Connections\PrimaryReadReplicaConnection;
-use Doctrine\DBAL\DBALException as DBAL2Exception;
-use Doctrine\DBAL\Exception as DBAL3Exception;
+use Doctrine\DBAL\Exception as DBALException;
 use Doctrine\Persistence\ConnectionRegistry;
 use Swarrot\Broker\Message;
 use Swarrot\Processor\ConfigurableInterface;
@@ -56,7 +54,7 @@ class ConnectionProcessor implements ConfigurableInterface
                 if ($connection->isConnected()) {
                     try {
                         $connection->query($connection->getDatabasePlatform()->getDummySelectSQL());
-                    } catch (DBAL2Exception|DBAL3Exception $e) {
+                    } catch (DBALException $e) {
                         $connection->close(); // close timed out connections so that using them connects again
                     }
                 }
@@ -68,10 +66,7 @@ class ConnectionProcessor implements ConfigurableInterface
         } finally {
             if ($options['doctrine_close_master']) {
                 foreach ($this->connections as $connection) {
-                    if (
-                        ($connection instanceof PrimaryReadReplicaConnection && $connection->isConnectedToPrimary())
-                        || ($connection instanceof MasterSlaveConnection && $connection->isConnectedToMaster())
-                    ) {
+                    if ($connection instanceof PrimaryReadReplicaConnection && $connection->isConnectedToPrimary()) {
                         $connection->close();
                     }
                 }

--- a/src/Swarrot/Processor/Doctrine/README.md
+++ b/src/Swarrot/Processor/Doctrine/README.md
@@ -7,10 +7,10 @@ to the master the connection would never switch back to the slave.
 
 ## Configuration
 
-|Key                  |Default|Description                                            |
-|:-------------------:|:-----:|-------------------------------------------------------|
-|doctrine_ping        |true   |Ping and close timed out connections                   |
-|doctrine_close_master|true   |Close MasterSlave connections connected to the master  |
+|Key                  |Default|Description                                               |
+|:-------------------:|:-----:|----------------------------------------------------------|
+|doctrine_ping        |true   |Ping and close timed out connections                      |
+|doctrine_close_master|true   |Close PrimaryReplica connections connected to the primary |
 
 # ObjectManagerProcessor
 


### PR DESCRIPTION
These dependencies are in the require-dev section not because they are
used for development, but because they are optional dependencies. This
means we already support recent versions of Doctrine, and it shows in
the codebase.Let's simplify and test against maintained versions only, it will
make it easier to upgrade other packages.
Composer outdated diff:

```patch
@@ -4,23 +4,12 @@
 - major release available - update possible

 Direct dependencies required in composer.json:
-doctrine/common                    2.13.3 3.4.3   PHP Doctrine Common project is a library that provides additional functionality that other Doctrine projects depend on such as better reflection support, persistence interfaces, proxies,...
-doctrine/dbal                      2.13.9 3.7.2   Powerful PHP database abstraction layer (DBAL) with many features for database schema introspection and management.
 phpunit/phpunit                    9.6.15 10.5.2  The PHP Unit Testing framework.
 symfony/error-handler              v6.4.0 v7.0.0  Provides tools to manage errors and ease debugging PHP code
 symfony/options-resolver           v6.4.0 v7.0.0  Provides an improved replacement for the array_replace PHP function
 symfony/phpunit-bridge             v6.4.1 v7.0.1  Provides utilities for PHPUnit, especially user deprecation notices management

 Transitive dependencies not required in composer.json:
-doctrine/annotations               1.14.3 2.0.1   Docblock Annotations Parser
-doctrine/cache                     1.13.0 2.2.0   PHP Doctrine Cache library is a popular cache implementation that supports many different drivers such as redis, memcache, apc, mongodb and others.
-doctrine/collections               1.8.0  2.1.4   PHP Doctrine Collections library that adds additional functionality on top of PHP arrays.
-doctrine/event-manager             1.2.0  2.0.0   The Doctrine Event Manager is a simple PHP event system that was built to be used with the various Doctrine projects.
-doctrine/inflector                 1.4.4  2.0.8   PHP Doctrine Inflector is a small library that can perform string manipulations with regard to upper/lowercase and singular/plural forms of words.
-doctrine/lexer                     1.2.3  3.0.0   PHP Doctrine Lexer parser library that can be used in Top-Down, Recursive Descent Parsers.
-doctrine/persistence               1.3.8  3.2.0   The Doctrine Persistence project is a set of shared interfaces and functionality that the different Doctrine object mappers share.
-doctrine/reflection                1.2.4  1.2.4   The Doctrine Reflection project is a simple library used by the various Doctrine projects which adds some additional functionality on top of the reflection functionality that comes with ...
-Package doctrine/reflection is abandoned, you should avoid using it. Use roave/better-reflection instead.
 phpunit/php-code-coverage          9.2.29 10.1.10 Library that provides collection, processing, and rendering functionality for PHP code coverage information.
 phpunit/php-file-iterator          3.0.6  4.1.0   FilterIterator implementation that filters files based on a list of suffixes.
 phpunit/php-invoker                3.1.1  4.0.0   Invoke callables with a timeout

```