### PR TITLE
Allow using the latest version of PHPUnit

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -23,7 +23,7 @@
         "phpspec/prophecy": "^1.15",
         "phpspec/prophecy-phpunit": "^2.0",
         "phpstan/phpstan": "^1.10",
-        "phpunit/phpunit": "^9.6",
+        "phpunit/phpunit": "^9.6 || ^10.0",
         "symfony/error-handler": "^5.4 || ^6.0 || ^7.0",
         "symfony/phpunit-bridge": "^5.4 || ^6.0 || ^7.0",
         "symfony/service-contracts": "^2.5 || ^3.0"


### PR DESCRIPTION
While it does not mean that we can use the latest features, it means we can spot and address deprecations earlier. It also means the output of composer outdated is smaller, which in turns allows us to spot where work is needed more easily.
Note that it also means running phpunit now also produces a warning about validating against a deprecated schema, and I do not think we can address it until we drop support for PHP <= 8.1, since PHPUnit 10 requires PHP 8.1+

This is similar to https://github.com/swarrot/SwarrotBundle/pull/230

After this, the output of `composer outdated` is empty :tada: 