### PR TITLE
Update missing illustration in README

### DIFF
--- a/README.md
+++ b/README.md
@@ -104,7 +104,7 @@ $processor = $stack->resolve(new Processor());
 
 Here is an illustration to show you what happens when this order is used:
 
-![this](https://docs.google.com/drawings/d/1Ea_QJHo-9p7YW8l_by7S4NID0e-AGpXRzzitAlYY5Cc/pub?w=960&h=720)
+![this](https://github.com/user-attachments/assets/b1aa419d-f10a-44ef-895b-a995c3215aa6)
 
 ## Processors
 


### PR DESCRIPTION
As the Google Docs URL is no longer up (hasn't been in a while apparently), I've got the illustration from the  [Internet Archive Project](https://web.archive.org/web/20200916002502im_/https://camo.githubusercontent.com/8ac89cd415aebfb1026b2278093dbcc986b126da/68747470733a2f2f646f63732e676f6f676c652e636f6d2f64726177696e67732f642f3145615f514a486f2d3970375957386c5f62793753344e494430652d41477058527a7a6974416c59593543632f7075623f773d39363026683d373230) and added it back as a GitHub attachment.