### PR TITLE
We need to talk about messenger

### DIFF
--- a/README.md
+++ b/README.md
@@ -5,6 +5,9 @@
 [![Latest Stable Version](https://poser.pugx.org/swarrot/swarrot/v/stable.svg)](https://packagist.org/packages/swarrot/swarrot)
 [![Latest Unstable Version](https://poser.pugx.org/swarrot/swarrot/v/unstable.svg)](https://packagist.org/packages/swarrot/swarrot)
 
+> [!IMPORTANT]
+> You should consider using [The Symfony Messenger Component](https://symfony.com/doc/current/components/messenger.html) instead of Swarrot. More contributors, more users, more features, this is probably the best choice you can do nowadays. :)
+
 Swarrot is a PHP library to consume messages from any broker.
 
 ## Installation


### PR DESCRIPTION
If swarrot was a great choice a few years ago, I'm convinced that messenger as much more to offer than swarrot nowadays.

This PR add an alert on top of the README to invite readers to use the Symfony Component instead of this lib.

WDYT @swarrot/maintainers ?