### PR TITLE
Improve connection with pecl

### DIFF
--- a/src/Swarrot/Broker/MessageProvider/PeclPackageMessageProvider.php
+++ b/src/Swarrot/Broker/MessageProvider/PeclPackageMessageProvider.php
@@ -18,7 +18,12 @@ class PeclPackageMessageProvider implements MessageProviderInterface
 
     public function get(): ?Message
     {
-        $envelope = $this->queue->get();
+        try {
+            $envelope = $this->queue->get();
+        } catch (\AMQPConnectionException $exception) {
+            $this->queue->getConnection()->reconnect();
+            $envelope = $this->queue->get();
+        }
 
         if (!$envelope instanceof \AMQPEnvelope) {
             return null;

--- a/src/Swarrot/Broker/MessageProvider/PeclPackageMessageProvider.php
+++ b/src/Swarrot/Broker/MessageProvider/PeclPackageMessageProvider.php
@@ -21,6 +21,9 @@ class PeclPackageMessageProvider implements MessageProviderInterface
         try {
             $envelope = $this->queue->get();
         } catch (\AMQPConnectionException $exception) {
+            // Try to reconnect once to accommodate need for one of the nodes in cluster needing to stop serving the
+            // traffic. This may happen for example when one of the nodes in cluster is going into maintenance node.
+            // see https://github.com/php-amqplib/php-amqplib/issues/1161
             $this->queue->getConnection()->reconnect();
             $envelope = $this->queue->get();
         }


### PR DESCRIPTION
Improve connection when using ext-amqp. Already implemented and explained in `symfony/messenger`.

```
Try to reconnect once to accommodate need for one of the nodes in cluster needing to stop serving the traffic. 
This may happen for example when one of the nodes in cluster is going into maintenance node.

See https://github.com/php-amqplib/php-amqplib/issues/1161
```

https://github.com/symfony/amqp-messenger/blob/7.2/Transport/AmqpReceiver.php#L53-L67